### PR TITLE
remove unnecessary ';' in sliding template

### DIFF
--- a/Resources/views/Pagination/sliding.html.twig
+++ b/Resources/views/Pagination/sliding.html.twig
@@ -3,7 +3,7 @@
 <div class="pagination">
   <ul>
     <li class="first {{ (first is defined and current == first) ? 'disabled' : ''}}">
-        <a href="{{ path(route, query|merge({'page': first})) }}">&#60;;&#60;</a>
+        <a href="{{ path(route, query|merge({'page': first})) }}">&#60;&#60;</a>
     </li>
 
     <li class="prev {{ (previous is not defined) ? 'disabled': ''}}">


### PR DESCRIPTION
Hi, I'm using your MopaBootstrapBundle and it's very nice.

You might have already fixed this.

Thank you.
