### PR TITLE
Problem when using help-inline and help-block in the same field

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -144,8 +144,8 @@
     {% if widget_remove_btn is defined %}
         {{ block('field_widget_remove_btn') }}
     {% endif %}
-        {{ block('field_help') }}
     {{ form_errors(form) }}
+    {{ block('field_help') }}
 {% endblock field_message %}
 
 {% block collection_widget %}


### PR DESCRIPTION
One small change can correctly show "error" (with help-inline) and "help" (with help-block) in a field.
