### PR TITLE
Fixed span16 to span12

### DIFF
--- a/Resources/views/flash.html.twig
+++ b/Resources/views/flash.html.twig
@@ -23,7 +23,7 @@
     {% endif %}
     {% if app.session.getFlashes()|length > 0 %}
         <div class="row">
-            <div class="{{ class|default('span16') }}">
+            <div class="{{ class|default('span12') }}">
                 {% if type|default(false) %}
                     {% if app.session.hasFlash(type) %}
                         {{ _self.flash(type, app.session.flash(type), close, use_raw) }}


### PR DESCRIPTION
In bootstrap V2, span16 is replaced by span12
