### PR TITLE
Remove inherited collection_widget

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -151,10 +151,6 @@
     {{ block('field_help') }}
 {% endblock field_message %}
 
-{% block collection_widget %}
-    {{ block('form_widget') }}
-{% endblock collection_widget %}
-
 {# Date and Time widgets #}
 
 {% block date_widget %}


### PR DESCRIPTION
By overriding the `collection_widget` from the Symfony2 form templates, we miss out on functionality from Symfony2's `data_prototype` (see below). So I think it's best to just remove the section.

```
{% block collection_widget %}
{% spaceless %}
    {% if prototype is defined %}
        {% set attr = attr|merge({'data-prototype': form_row(prototype) }) %}
    {% endif %}
    {{ block('form_widget') }}
{% endspaceless %}
{% endblock collection_widget %}
```
