### PR TITLE
Change Twitter bootstrap requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "twitter/bootstrap": "master"
+        "twitter/bootstrap": ">=2.0.0"
     },
      "scripts": {
         "post-package-install": [


### PR DESCRIPTION
Change Twitter bootstrap requirement from `master` to `>=2.0.0`. This has the advantage that users can lock their Twitter bootstrap version to a stable version (e.g., `2.0.1` or `2.0.2`) instead of having to update to `master` because of the MopaBootstrapBundle requirement. 
