### PR TITLE
Removed un-needed paragraph from flash messages.

### DIFF
--- a/Resources/views/flash.html.twig
+++ b/Resources/views/flash.html.twig
@@ -3,13 +3,12 @@
 	{% if close|default(false) %}
             <a class="close" data-dismiss="alert" href="#">×</a>
 	{% endif %}
-	<p>
-            {% if use_raw|default(false) %}
-                {{ message|trans|raw }}
-            {% else %}
-                {{ message|trans }}
-            {% endif %}
-	</p>
+	
+	{% if use_raw|default(false) %}
+	    {{ message|trans|raw }}    
+	{% else %}
+	    {{ message|trans }}
+	{% endif %}
     </div>
 {% endmacro %}
 


### PR DESCRIPTION
The alert css style already adds necessary padding, this p tag was making the alert box bigger and awkward looking.
