### PR TITLE
fix the index counter when using 'allow_add'=>true for embedded forms

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -27,7 +27,9 @@
   var Collection = function ( element, options ) {
     this.$element = $(element)
     this.options = $.extend({}, $.fn.collection.defaults, options)
-    this.options.index = this.$element.parents('div'+this.options.collection_id+' .collection.controls').length;
+
+    var embeddedForms = 'div'+this.options.collection_id+'>.collection.controls>.collection-item';
+    this.options.index = $( embeddedForms ).length - 1;
   }
 
   Collection.prototype = {
@@ -64,7 +66,10 @@
         , collection_id = '#'+$this.data('collection-add-btn')
         , collection = $(collection_id)
         , data = $this.data('collection')
-        , options = typeof option == 'object' && option
+        , options = typeof option == 'object' ? option : {}
+
+      options.collection_id = collection_id;
+
       if (!data) $this.data('collection', (data = new Collection(this, options)))
       data.options.collection_id = collection_id;
       if (option == 'add') data.add()


### PR DESCRIPTION
## Issues

The add button is not working here, the index instantiated is almost always incorrect (always equal to 0).

In the constructor there https://github.com/phiamo/MopaBootstrapBundle/blob/v2.x_sf2.0/Resources/public/js/mopabootstrap-collection.js#L30, the value

```
this.options.collection_id 
```

is not set

Looking at https://github.com/phiamo/MopaBootstrapBundle/blob/v2.x_sf2.0/Resources/public/js/mopabootstrap-collection.js#L68 it seems that the option object doesnt contain collection_id (and I dont get how you define options???)

I also dont understand why calling length on $('.collection.controls') to calculate this.options.index in https://github.com/phiamo/MopaBootstrapBundle/blob/v2.x_sf2.0/Resources/public/js/mopabootstrap-collection.js#L30. 

This is the parent, and the index should be the number of embedded forms, something like:

```
$('.collection.controls > .collection.controls > div.collection-item').length - 1
```
## PR

this code is working here and resolves the issues above.

Please propagate the change to v2.x_sf2.0 as well !
