### PR TITLE
Fix undefined var error

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -352,7 +352,7 @@
 
 {% block error_type %}
 {% spaceless %}
-{% if form_error_type %}
+{% if form_error_type is defined and form_error_type %}
 {{ form_error_type }}
 {% elseif form.hasParent() != 0 %}
     {% set form = form.parent %}


### PR DESCRIPTION
Hi,

I got an error in the fields.html.twig : form_error_type was not defined with my version of Symfony / twitter bootstrap. I did not investigated more than this, i just forked and added a "is defined" check before you use the variable.
