### PR TITLE
Added translation domain for form labels/options

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -41,7 +41,7 @@
             {% for child in form %}
                 <label class="{{ widget_type ~ (multiple ? ' checkbox' : ' radio') }}">
                     {{ form_widget(child, {'attr': {'class': attr.widget_class|default('')}}) }}
-                    {{ child.get('label')|trans }}
+                    {{ child.get('label')|trans({}, translation_domain) }}
                 </label>
             {% endfor %}
             {{ block('form_message') }}
@@ -50,7 +50,7 @@
     {% else %}
             <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
                 {% if empty_value is not none %}
-                <option value="">{{ empty_value|trans }}</option>
+                <option value="">{{ empty_value|trans({}, translation_domain) }}</option>
                 {% endif %}
                 {% if preferred_choices|length > 0 %}
                     {% set options = preferred_choices %}
@@ -139,7 +139,7 @@
 {# Labels #}
 
 {% block form_legend %}
-          <legend>{{ label | trans }}</legend>
+          <legend>{{ label|trans({}, translation_domain) }}</legend>
 {% endblock form_legend %}
 
 {% block generic_label %}
@@ -149,13 +149,13 @@
     {% endif %}
     {% set attr = attr|merge({'class': attr.class|default('') ~ ' control-label'}) %}
     <label{% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
-    {{ label|trans }}
+    {{ label|trans({}, translation_domain) }}
     {% if required %}*{% endif %}
     {% if widget_add_btn %}
         {{ block('form_widget_add_btn') }}
     {% endif %}
     {% if help_label %}
-        <p class="help-block">{{ help_label|trans }}</p>
+        <p class="help-block">{{ help_label|trans({}, translation_domain) }}</p>
     {% endif %}
     </label>
 {% endspaceless %}


### PR DESCRIPTION
Since it is possible to define a translation domain for each field, this should be also considered in the template.
