### PR TITLE
Fix variable typo (error_type should be form_error_type)

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -358,7 +358,7 @@
     {% set form = form.parent %}
     {{ block('error_type') }}
 {% elseif form.hasParent() == 0 %}
-    {{ form.get('error_type') }}
+    {{ form.get('form_error_type') }}
 {% endif %}
 {% endspaceless %}
 {% endblock error_type %}


### PR DESCRIPTION
Since c295804 you haven't been able to set the error_type for an entire form, this fixes that.
