### PR TITLE
New control_attr attribute in form_row

### DIFF
--- a/Form/Extension/WidgetFormTypeExtension.php
+++ b/Form/Extension/WidgetFormTypeExtension.php
@@ -25,6 +25,7 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
         $builder->setAttribute('widget_prefix', $options['widget_prefix']);
         $builder->setAttribute('widget_suffix', $options['widget_suffix']);
         $builder->setAttribute('widget_type',   $options['widget_type']);
+        $builder->setAttribute('control_attr', $options['control_attr']);
     }
 
     public function buildView(FormView $view, FormInterface $form)
@@ -35,6 +36,7 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
         $view->set('widget_prefix', $form->getAttribute('widget_prefix'));
         $view->set('widget_suffix', $form->getAttribute('widget_suffix'));
         $view->set('widget_type',   $form->getAttribute('widget_type'));
+        $view->set('control_attr',   $form->getAttribute('control_attr'));
     }
 
     public function getDefaultOptions()
@@ -50,6 +52,7 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
             'widget_prefix' => null,
             'widget_suffix' => null,
             'widget_type' => '',
+            'control_attr' => array(),
         );
     }
     public function getAllowedOptionValues()

--- a/Resources/doc/form_extensions.md
+++ b/Resources/doc/form_extensions.md
@@ -202,3 +202,24 @@ public function buildForm(FormBuilder $builder, array $options)
     ;
     //...
 ```
+
+<h3 id="Control_Tags">Control tag</h3>
+
+
+This is maybe a little hack but i didn't know howto come around the attr inheritance of the form to the control tag.
+So i made another form extenstion so you can explicitly set the classes of the control tag, 
+by default there is only the control-group and the error (if the widget has error) classes rendered into it :
+
+``` php
+       $builder
+            ->add('somefield', null, array( 
+                'control_attr' => array('class'=>'mycontrolclass')
+            ))
+```
+
+will result in
+ 
+``` html
+<div id="myWidgetName_control_group" class="mycontrolclass control-group">
+... 
+```

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -192,9 +192,12 @@
 	{% set attr = attr|merge({'class': attr.class|default('') ~ (errors|length > 0 ? ' error' : '') }) %}
     {% if form.children|length == 0 %}
         {% if widget_control_group and not _isCollectionItem %}
-            {% set oid = id %}
-            {% set id = oid ~ "_control_group" %}
-    <div class="control-group{% if errors|length > 0 %} error{% endif %}" {{ block('widget_attributes') }}>
+            {% set control_attr = control_attr|merge({'class': control_attr.class|default('') ~ ' control-group'}) %}
+            {% set control_attr = control_attr|merge({'id': id ~ "_control_group"}) %}
+            {% if errors|length > 0 %}
+                {% set control_attr = control_attr|merge({'class': control_attr.class|default('') ~ ' error'}) %}
+            {% endif %}
+    <div{% for attrname,attrvalue in control_attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
             {% set id = oid %}
         {% endif %}
     {% endif %}


### PR DESCRIPTION
Add a new control_attr option to form_row allow users to puts some attributes on the control div container. The wrong attributes like required, maxlength … will not show now.
