### PR TITLE
Re-applied money field customization, closes #110

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -114,6 +114,13 @@
 {% endspaceless %}
 {% endblock percent_widget %}
 
+{% block money_widget %}
+{% spaceless %}
+    {% set widget_addon = widget_addon|merge({'text': money_pattern|replace({ '{{ widget }}': ''})}) %}
+    {{ block('form_widget_single_control') }}
+{% endspaceless %}
+{% endblock money_widget %}
+
 {# Labels #}
 
 {% block form_legend %}


### PR DESCRIPTION
Money symbol is prepended to field instead of just being echo'd before it.
