### PR TITLE
Fixes a bug where use_raw argument is not correctly passed to flash() macro

### DIFF
--- a/Resources/views/flash.html.twig
+++ b/Resources/views/flash.html.twig
@@ -34,7 +34,7 @@
     {% if app.session.flashbag.peekAll|length > 0 %}
         {% for type, messages in app.session.flashbag.all %}
             {% for message in messages %}
-                {{ _self.flash(type, message, close|default(false, use_raw|default(false))) }}
+                {{ _self.flash(type, message, close|default(false), use_raw|default(false)) }}
             {% endfor %}
         {% endfor %}
     {% endif %}


### PR DESCRIPTION
Fixes a bug where use_raw argument is not correctly passed to flash() macro
