### PR TITLE
Fix money widget default widget_addon type

### DIFF
--- a/Form/Extension/WidgetFormTypeExtension.php
+++ b/Form/Extension/WidgetFormTypeExtension.php
@@ -26,6 +26,11 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
                 $options['widget_addon']['type'] = 'append';
             }
         }
+        if (in_array('money', $view->getVar('types'))) {
+            if ($options['widget_addon']['type'] === null) {
+                $options['widget_addon']['type'] = 'prepend';
+            }
+        }
         if (($options['widget_addon']['text'] !== null || $options['widget_addon']['icon'] !== null) && $options['widget_addon']['type'] === null) {
             throw new \Exception('You must provide a "type" for widget_addon');
         }


### PR DESCRIPTION
Currently, if you do not explicitly set the widget_addon type for the money widget the addon will not show. This fixes that.
