### PR TITLE
Fix collection rows being added multiple times

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -45,7 +45,7 @@
                 return;
             }
             row = $(this.options.collection_id).attr('data-prototype').replace(/__name__/g, index);
-            $('div' + this.options.collection_id + ' .controls').append($('<div />').html(row).text());
+            $('div' + this.options.collection_id + '> .controls').append($('<div />').html(row).text());
         },
         remove: function () {
                 if (this.$element.parents('.collection-item').length !== 0){


### PR DESCRIPTION
Fixes a bug that caused collection rows to be added multiple times to
the DOM. This was caused by the selector selecting all children with the
class .controls, which in turn meant that you couldn't use control
groups in subforms.
