### PR TITLE
Don't escape data-prototype twice (fixes #177)

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -315,14 +315,8 @@
 {% spaceless %}
 {% if widget_control_group|default(false) or not form.hasParent() %}
     {% if prototype is defined %}
-        {% set data_prototype %}
-        {% spaceless %}
-        <div class="collection-item">
-            {{ form_row(prototype) }}
-        </div>
-        {% endspaceless %}
-        {% endset %}
-        {% set widget_control_group_attr = widget_control_group_attr|merge({'data-prototype': data_prototype|e}) %}
+        {% set data_prototype = '<div class="collection-item">' ~ form_row(prototype) ~ '</div>' %}
+        {% set widget_control_group_attr = widget_control_group_attr|merge({'data-prototype': data_prototype}) %}
     {% endif %}
     {% set widget_control_group_attr = widget_control_group_attr|merge({'id': id ~ '_control_group', 'class': widget_control_group_attr.class|default('') ~ ' control-group'}) %}
     {% if errors|length > 0 %}


### PR DESCRIPTION
This works for me. If there's a more elegant way to do this, please use that.
