### PR TITLE
Add default caret for dropdown menu in navbar

### DIFF
--- a/Navbar/AbstractNavbarMenuBuilder.php
+++ b/Navbar/AbstractNavbarMenuBuilder.php
@@ -84,6 +84,9 @@ abstract class AbstractNavbarMenuBuilder
             $icon = array_merge(array('tag'=>'i'), $icon);
             $dropdown->setLabel($title. ' <'.$icon['tag'].' class="'.$icon['icon'].'"></'.$icon['tag'].'>')
                      ->setExtra('safe_label', true);
+        } else {
+            $dropdown->setLabel($title.' <b class="caret"></b>')
+                     ->setExtra('safe_label', true);
         }
 
         return $dropdown;

--- a/Resources/public/less/subnav.less
+++ b/Resources/public/less/subnav.less
@@ -69,6 +69,30 @@
           border-radius: 0 0 4px 4px;
 }
 
+.caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  vertical-align: top;
+  border-top: 4px solid #000000;
+  border-right: 4px solid transparent;
+  border-left: 4px solid transparent;
+  content: "";
+  opacity: 0.3;
+  filter: alpha(opacity=30);
+}
+
+.dropdown .caret {
+  margin-top: 8px;
+  margin-left: 2px;
+}
+
+.dropdown:hover .caret,
+.open .caret {
+  opacity: 1;
+  filter: alpha(opacity=100);
+}
+
 /* Fixed subnav on scroll, but only for 980px and up (sorry IE!) */
 @media (min-width: 980px) {
   .subnav-fixed {


### PR DESCRIPTION
Add a default caret when no icon is provided for dropdown menu in navbar, and also add related CSS.
