### PR TITLE
Enables the usage of the config option for the fields file

### DIFF
--- a/DependencyInjection/Compiler/FormPass.php
+++ b/DependencyInjection/Compiler/FormPass.php
@@ -28,9 +28,7 @@ class FormPass implements CompilerPassInterface
     {
         if ($container->getParameter('mopa_bootstrap.form.templating')) {
             $resources = $container->getParameter('twig.form.resources');
-    
-            $resources[] = 'MopaBootstrapBundle:Form:fields.html.twig';
-    
+
             $container->setParameter('twig.form.resources', $resources);
         }
     }


### PR DESCRIPTION
Removing the code enables the use of a different fields file through the symfony 2 config:

``` yml
twig:
    debug:            %kernel.debug%
    strict_variables: %kernel.debug%
    form:
        resources:
            #- 'MopaBootstrapBundle:Form:fields.html.twig'
            - 'MyBundle:Form:fields.html.twig'
```
