### PR TITLE
JQuery "$ not defined" error.

### DIFF
--- a/Resources/views/Pagination/sliding.html.twig
+++ b/Resources/views/Pagination/sliding.html.twig
@@ -27,9 +27,9 @@
 </div>
 {% endif %}
 <script type="text/javascript">
-$(document).ready(function(){
+if (typeof jQuery == 'defined') {  
     $('.pagination li.disabled a').click(function (e) {
         e.preventDefault()
     });
-});
+}
 </script>


### PR DESCRIPTION
When using sliding.html.twig a JQuery error appears in the console "$ not defined". I went to ahead and fixed this error by checking to see if JQuery is defined first. 
