### PR TITLE
Change insertion logic in FormPass. 

### DIFF
--- a/DependencyInjection/Compiler/FormPass.php
+++ b/DependencyInjection/Compiler/FormPass.php
@@ -29,7 +29,10 @@ class FormPass implements CompilerPassInterface
         if ($container->getParameter('mopa_bootstrap.form.templating')) {
             $resources = $container->getParameter('twig.form.resources');
     
-            $resources[] = 'MopaBootstrapBundle:Form:fields.html.twig';
+            //Ensures Mopa comes in before other resources
+            $coreResource = array_shift($resources);
+            array_unshift($resources, 'MopaBootstrapBundle:Form:fields.html.twig');
+            array_unshift($resources, $coreResource);
     
             $container->setParameter('twig.form.resources', $resources);
         }


### PR DESCRIPTION
For other resources to be able to extend the Mopa form templates it cannot be the last resource, the changes allow it to always be the second resource parsed, just after the core form_div_layout resource.

This refers to the issue described in #199
