### PR TITLE
add KnpMenu Twig template supporting icon extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Additional Resources:
 Installation
 ------------
 
-Installation instructions are located in the 
+Installation instructions are located in the
 
 * [master documentation](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/1-installation.md).
 * [2.0.x documentation](https://github.com/phiamo/MopaBootstrapBundle/tree/v2.0.x#installation).
@@ -53,6 +53,8 @@ Included Features
   * helpers for dropdowns, seperators, etc.
 * twig templates for KnpPaginatorBundle (https://github.com/knplabs/KnpPaginatorBundle)
 * twig templates for CraueFormFlowBundle (https://github.com/craue/CraueFormFlowBundle)
+* twig template for KnpMenu (https://github.com/KnpLabs/KnpMenu)
+  * icon support on menu links
 
 Recently added Features
 -----------------------
@@ -86,10 +88,10 @@ Warning
 
 Translations
 ------------
-If you use [KnpPaginatorBundle](https://github.com/KnpLabs/KnpPaginatorBundle) with MopaBootstrapBundle, you can translate labels to your language.  
-To do this add new file  
+If you use [KnpPaginatorBundle](https://github.com/KnpLabs/KnpPaginatorBundle) with MopaBootstrapBundle, you can translate labels to your language.
+To do this add new file
 
-```Resources/translations/pagination.[YOUR LOCALE CODE].yml```  
+```Resources/translations/pagination.[YOUR LOCALE CODE].yml```
 
 As example you have there Polish translation.
 

--- a/Resources/doc/99-support-for-other-bundles.md
+++ b/Resources/doc/99-support-for-other-bundles.md
@@ -36,3 +36,62 @@ mkdir -p app/Resources/Knp/Bundle/PaginatorBundle/views/Pagination/
 cp vendor/bundles/Mopa/BootstrapBundle/Resources/views/Pagination/* app/Resources/Knp/Bundle/PaginatorBundle/views/Pagination/
 ```
 
+For KnpMenu use the following parameter to make use of the menu template:
+
+```yaml
+# File: app/configs/parameters.yml
+
+parameters:
+    knp_menu.renderer.twig.template: MopaBootstrapBundle:Menu:menu.html.twig
+```
+
+By using this template, you can make use of the `icon` and `icon_white` extra attributes.
+The example shows the usage within a `Navbar`, however it works with any `knp_menu_render` in a Twig template.
+
+```php
+<?php
+# File: src/Acme/Bundle/AcmeDemoBundle/Menu/NavbarMenuBuilder.php
+
+namespace Acme\Bundle\AcmeDemoBundle\Menu;
+
+use Mopa\Bundle\BootstrapBundle\Navbar\AbstractNavbarMenuBuilder;
+
+class NavbarMenuBuilder extends AbstractNavbarMenuBuilder
+{
+    public function createMainMenu(Request $request)
+    {
+        $menu = $this->factory->createItem('root');
+        $menu->setCurrentUri($request->getRequestUri());
+        $menu->setChildrenAttribute('class', 'nav');
+
+        $dropdown = $this->createDropdownMenuItem($menu, 'Account');
+        $dropdown->addChild('Register', array(
+            'route' => 'register'
+        ));
+
+        $this->addDivider($dropdown);
+        $dropdown->addChild('Login', array(
+            'route' => 'login_form',
+            'extras' => array(
+                'icon' => 'signin',
+            ),
+        ));
+        $dropdown->addChild('Login via Facebook', array(
+            'route' => 'login_facebook',
+            'extras' => array(
+                'icon' => 'facebook',
+                'icon_white' => true,
+            ),
+        ));
+        $dropdown->addChild('Login via Google+', array(
+            'route' => 'login_google',
+            'extras' => array(
+                'icon' => 'google-plus',
+            ),
+        ));
+
+        return $menu;
+    }
+}
+```
+

--- a/Resources/views/Menu/menu.html.twig
+++ b/Resources/views/Menu/menu.html.twig
@@ -1,0 +1,7 @@
+{% extends 'knp_menu.html.twig' %}
+
+{% block linkElement %}
+{% import 'knp_menu.html.twig' as macros %}
+{% from 'MopaBootstrapBundle::icons.html.twig' import icon %}
+<a href="{{ item.uri }}"{{ macros.attributes(item.linkAttributes) }}>{% if item.extras.icon|default(false) %}{{ icon(item.extras.icon, item.extras.icon_white|default(false)) }}{% endif %}{{ block('label') }}</a>
+{% endblock %}


### PR DESCRIPTION
Add support of icon-\* using extra attributes on KnpMenu.

It's compatible with any menu, including navbar and drop-down menus; demo screenshot: http://bit.ly/L8QsIV 
