### PR TITLE
Trigger event when adding a row to a form collection

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -46,8 +46,11 @@
             this.addPrototype(index);
         },
         addPrototype: function(index) {
-            var row = $(this.options.collection_id).attr('data-prototype').replace(/__name__/g, index);
-            $('div' + this.options.collection_id + '> .controls').append($('<div />').html(row));
+            var rowContent = $(this.options.collection_id).attr('data-prototype').replace(/__name__/g, index);
+            var row = $("<div />");
+            row.html(rowContent);
+            $('div' + this.options.collection_id + '> .controls').append(row);
+            $(this.options.collection_id).trigger('add', [row]);
         },
         remove: function () {
                 if (this.$element.parents('.collection-item').length !== 0){


### PR DESCRIPTION
Modified mopabootstrap-collection.js to trigger an event on the control-group when adding a row.

Usage example:

```
$('#collection_element_control_group').bind('add', function (event, row) {
    // Row contains the row that has just been added
    row.addClass('new-row');
});
```
