### PR TITLE
Fix for nested collection problem

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -51,7 +51,7 @@
         },
         remove: function () {
                 if (this.$element.parents('.collection-item').length !== 0){
-                    this.$element.parents('.collection-item').remove();
+                    this.$element.parent('.collection-item').remove();
                 }
         }
 


### PR DESCRIPTION
when you nested some collection, when you click the erase button, all the parents are closed and that isn't the behaviour
