### PR TITLE
Synced form extensions with Symfony Master

### DIFF
--- a/Form/Extension/ErrorTypeFormTypeExtension.php
+++ b/Form/Extension/ErrorTypeFormTypeExtension.php
@@ -3,7 +3,7 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormViewInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class ErrorTypeFormTypeExtension extends AbstractTypeExtension
@@ -14,7 +14,7 @@ class ErrorTypeFormTypeExtension extends AbstractTypeExtension
     {
         $this->error_type = $options['error_type'];
     }
-    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->addVars(array(
             'error_type' =>  $options['error_type'],

--- a/Form/Extension/HelpFormTypeExtension.php
+++ b/Form/Extension/HelpFormTypeExtension.php
@@ -3,12 +3,12 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormViewInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class HelpFormTypeExtension extends AbstractTypeExtension
 {
-    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->addVars(array(
             'help_inline' => $options['help_inline'],

--- a/Form/Extension/LegendFormTypeExtension.php
+++ b/Form/Extension/LegendFormTypeExtension.php
@@ -3,7 +3,7 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormViewInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class LegendFormTypeExtension extends AbstractTypeExtension
@@ -21,7 +21,7 @@ class LegendFormTypeExtension extends AbstractTypeExtension
         $this->render_required_asterisk = $options['render_required_asterisk'];
     }
 
-    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->addVars(array(
             'render_fieldset' =>            $options['render_fieldset'],

--- a/Form/Extension/WidgetCollectionFormTypeExtension.php
+++ b/Form/Extension/WidgetCollectionFormTypeExtension.php
@@ -3,7 +3,7 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormViewInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Exception\FormException;
 
@@ -16,7 +16,7 @@ class WidgetCollectionFormTypeExtension extends AbstractTypeExtension
         $this->options = $options;
     }
 
-    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options)
     {
         if ($options['widget_add_btn'] != null && !is_array($options['widget_add_btn'])) {
             throw new FormException('The "widget_add_btn" option must be an "array".');

--- a/Form/Extension/WidgetFormTypeExtension.php
+++ b/Form/Extension/WidgetFormTypeExtension.php
@@ -3,14 +3,14 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormViewInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Exception\CreationException;
 
 class WidgetFormTypeExtension extends AbstractTypeExtension
 {
 
-    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options)
     {
         if (!is_array($options['widget_addon'])) {
             throw new CreationException("The 'widget_addon' option must be an array");


### PR DESCRIPTION
FormTypeExtensionInterface recently changed and the form extensions were no longer compatible with the interface. buildView no longer takes a FormViewInterface as the first param, just a FormView.

See this PR https://github.com/symfony/symfony/pull/5004
