### PR TITLE
Fixing further references to 'types'

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -60,11 +60,11 @@
 
 {% block checkbox_widget %}
 {% spaceless %}
-{% if form.hasParent() and 'choice' not in form.parent.vars.types %}
+{% if form.hasParent() and 'choice' not in form.parent.vars.block_prefixes %}
   <label class="checkbox">
 {% endif %}
       <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}> {{ help_inline|trans|raw }}
-{% if form.hasParent() and 'choice' not in form.parent.vars.types %}
+{% if form.hasParent() and 'choice' not in form.parent.vars.block_prefixes %}
 {% set help_inline = false %}
 </label>
 {% endif %}
@@ -179,12 +179,12 @@
         </div>
     {% endif %}
     {% for child in form %}
-        {% if 'hidden' not in child.vars.types %}
-            {% if 'collection' in form.vars.types and not ommit_collection_item %}
+        {% if 'hidden' not in child.vars.block_prefixes %}
+            {% if 'collection' in form.vars.block_prefixes and not ommit_collection_item %}
             <div class="collection-item">
             {% endif %}
             {{ form_row(child) }}
-            {% if 'collection' in form.vars.types and not ommit_collection_item %}
+            {% if 'collection' in form.vars.block_prefixes and not ommit_collection_item %}
             </div>
             {% endif %}
         {% endif %}
@@ -218,7 +218,7 @@
 
 {% block form_help %}
 {% spaceless %}
-{% if 'checkbox' not in form.vars.types %}{# checkbox widget/choice widget problem see https://github.com/phiamo/MopaBootstrapBundle/commit/67406a16b38e5b622fffdd5b9c8a8707ca73f493#commitcomment-1295951 # #}
+{% if 'checkbox' not in form.vars.block_prefixes %}{# checkbox widget/choice widget problem see https://github.com/phiamo/MopaBootstrapBundle/commit/67406a16b38e5b622fffdd5b9c8a8707ca73f493#commitcomment-1295951 # #}
     {% if help_inline %}<p class="help-inline">{{ help_inline|trans|raw }}</p>{%endif %}
 {% endif %}
 {% if help_block %}<p class="help-block">{{ help_block|trans|raw }}</p>{%endif %}
@@ -330,9 +330,9 @@
         {% set widget_control_group_attr = widget_control_group_attr|merge({'class': widget_control_group_attr.class|default('') ~ ' error'}) %}
     {% endif %}
     <div {% for attrname,attrvalue in widget_control_group_attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
-    {# a form item containing the field in types is a near subform or a field directly #}
+    {# a form item containing the field in block_prefixes is a near subform or a field directly #}
     {% if (form.hasChildren() and form.hasParent())  
-    	and not 'field' in form.vars.types %}
+        and not 'field' in form.vars.block_prefixes %}
         {% if show_child_legend%}
             {{ block('form_legend') }}
         {% endif %}


### PR DESCRIPTION
Updated template references to 'types' to 'blockPrefixes'. This complements #230
