### PR TITLE
Inline and label support for checkbox_widget.

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -49,10 +49,10 @@
 {% spaceless %}
     <div {{ block('widget_container_attributes') }}>
     {% for child in form %}
-            <label class="{{ widget_type ~ (multiple ? ' checkbox' : ' radio') }}">
-                {{ form_widget(child, {'attr': {'class': attr.widget_class|default('')}}) }}
-                {{ child.vars.label|trans({}, translation_domain) }}
-            </label>
+        <label class="{{ (multiple ? 'checkbox' : 'radio') ~ (widget_type ? ' ' ~ widget_type : '') ~ (inline is defined and inline ? ' inline' : '') }}">
+            {{ form_widget(child, {'attr': {'class': attr.widget_class|default('')}}) }}
+            {{ child.vars.label|trans({}, translation_domain) }}
+        </label>
     {% endfor %}
     </div>
 {% endspaceless %}
@@ -61,12 +61,13 @@
 {% block checkbox_widget %}
 {% spaceless %}
 {% if form.hasParent() and 'choice' not in form.parent.vars.block_prefixes %}
-  <label class="checkbox">
+    <label class="checkbox{% if inline is defined and inline %} inline{% endif %}">
 {% endif %}
-      <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}> {{ help_inline|trans|raw }}
+        <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}> {{ help_inline|trans|raw }}
 {% if form.hasParent() and 'choice' not in form.parent.vars.block_prefixes %}
-{% set help_inline = false %}
-</label>
+        {{ label }}
+        {% set help_inline = false %}
+    </label>
 {% endif %}
 {% endspaceless %}
 {% endblock checkbox_widget %}


### PR DESCRIPTION
Added inline support for checkbox_widget, for use directly or via choice_widget_expanded.
Added label option to pass a value through to checkbox_widget.

Also some minor refactoring and re-indenting surrounding these two.
