### PR TITLE
fix PHP Fatal error in master-crud

### DIFF
--- a/Form/Extension/HelpFormTypeExtension.php
+++ b/Form/Extension/HelpFormTypeExtension.php
@@ -3,12 +3,12 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormViewInterface;
-use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class HelpFormTypeExtension extends AbstractTypeExtension
 {
-    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->addVars(array(
             'help_inline' => $options['help_inline'],
@@ -17,13 +17,13 @@ class HelpFormTypeExtension extends AbstractTypeExtension
         ));
     }
 
-    public function getDefaultOptions()
+    public function getDefaultOptions(OptionsResolverInterface $resolver)
     {
-        return array(
+        $resolver->setDefaults(array(
             'help_inline' => null,
             'help_block' => null,
             'help_label' => null,
-        );
+        ));
     }
     public function getExtendedType()
     {


### PR DESCRIPTION
Declaration of Mopa\Bundle\BootstrapBundle\Form\Extension\HelpFormTypeExtension::buildView() must be compatible with Symfony \Component\Form\FormTypeExtensionInterface::buildView(Symfony\Component\Form\FormView $view, Symfony\Component\Form\FormInterface $form, array  $options)
