### PR TITLE
Removed JS dependency for FormFlow keyboard submission.

### DIFF
--- a/Resources/views/Form/formflow_buttons.html.twig
+++ b/Resources/views/Form/formflow_buttons.html.twig
@@ -1,5 +1,5 @@
 {% set renderBackButton = flow.getCurrentStep() in (flow.getFirstStep() + 1) .. flow.getLastStep() %}
-<div class="form_actions form_flow_actions">
+<div class="form-actions form-flow-actions">
     {#
         Default button (the one trigged by pressing the enter/return key) must be defined first.
         Thus, all buttons are defined in reverse order and will be reversed again via CSS.


### PR DESCRIPTION
Bootstrap doesn't require JS, swapping out @craue's research-backed solution to enter key submission seems backwards, reverted, + some other adjustments to bring back inline with CraueFormFlowBundle.

Perhaps this bundle should include some default styling for the `form_flow` class I've added.
