### PR TITLE
Fixed FormFlow button rendering when skipping steps.

### DIFF
--- a/Resources/views/Form/formflow_buttons.html.twig
+++ b/Resources/views/Form/formflow_buttons.html.twig
@@ -9,7 +9,7 @@ append class="bootstrap_formflow" to your form: #}
         {{- 'button.back' | trans({}, 'CraueFormFlowBundle') -}}
     </button>
     <button type="submit" id="next" class="btn btn-primary">
-        {%- if flow.getCurrentStep() < flow.getMaxSteps() -%}
+        {%- if flow.getCurrentStep() < flow.getLastStep() -%}
             {{- 'button.next' | trans({}, 'CraueFormFlowBundle') -}}
         {%- else -%}
             {{- 'button.finish' | trans({}, 'CraueFormFlowBundle') -}}


### PR DESCRIPTION
When skipping steps the getMaxSteps function by definition returns all possible steps, getLastStep takes into account any skipped steps and allows for correct rendition of next/finish button.
