### PR TITLE
Removed JS dependency for FormFlow keyboard submission.

### DIFF
--- a/Resources/views/Form/formflow_buttons.html.twig
+++ b/Resources/views/Form/formflow_buttons.html.twig
@@ -1,33 +1,23 @@
-{% set renderBackButton = flow.getCurrentStep() in 2 .. flow.getMaxSteps() %}
-{# Since bootstrap relies on jQuery or Ender, we can use a Js to make Enter intercept the next button
-append class="bootstrap_formflow" to your form: #}
-<div class="form_actions">
-    <button type="submit" id="reset" class="btn" name="{{ flow.getFormTransitionKey() }}" value="reset" formnovalidate="formnovalidate">
-        {{- 'button.reset' | trans({}, 'CraueFormFlowBundle') -}}
-    </button>
-    <button type="submit" id="back" name="{{ flow.getFormTransitionKey() }}" value="back" formnovalidate="formnovalidate" class="btn{% if not renderBackButton %} disabled{% endif %}"{% if not renderBackButton %} disabled="disabled"{% endif %}>
-        {{- 'button.back' | trans({}, 'CraueFormFlowBundle') -}}
-    </button>
-    <button type="submit" id="next" class="btn btn-primary">
-        {%- if flow.getCurrentStep() < flow.getLastStep() -%}
+{% set renderBackButton = flow.getCurrentStep() in (flow.getFirstStep() + 1) .. flow.getLastStep() %}
+<div class="form-actions form-flow-actions">
+    {#
+        Default button (the one trigged by pressing the enter/return key) must be defined first.
+        Thus, all buttons are defined in reverse order and will be reversed again via CSS.
+        See http://stackoverflow.com/questions/1963245/multiple-submit-buttons-specifying-default-button
+    #}
+    <button type="submit" class="btn btn-primary">
+        {%- if flow.getCurrentStep() < flow.getMaxSteps() -%}
             {{- 'button.next' | trans({}, 'CraueFormFlowBundle') -}}
         {%- else -%}
             {{- 'button.finish' | trans({}, 'CraueFormFlowBundle') -}}
         {%- endif -%}
     </button>
-</div>
 
-<script type="text/javascript">
-$(function() {
-    $(function() {
-        $("form{{ formident|default('') }} input").keypress(function (e) {
-            if ((e.which && e.which == 13) || (e.keyCode && e.keyCode == 13)) {
-                $('button[type=submit].btn-primary').click();
-                return false;
-            } else {
-                return true;
-            }
-        });
-    });
-});
-</script>
+    <button type="submit" name="{{ flow.getFormTransitionKey() }}" value="back" class="btn{% if not renderBackButton %} disabled{% endif %}" formnovalidate="formnovalidate"{% if not renderBackButton %} disabled="disabled"{% endif %}>
+        {{- 'button.back' | trans({}, 'CraueFormFlowBundle') -}}
+    </button>
+
+    <button type="submit" name="{{ flow.getFormTransitionKey() }}" value="reset" class="btn" formnovalidate="formnovalidate">
+        {{- 'button.reset' | trans({}, 'CraueFormFlowBundle') -}}
+    </button>
+</div>


### PR DESCRIPTION
Bootstrap doesn't require JS, swapping out @craue's research-backed solution to enter key submission seems backwards, reverted, + some other adjustments to bring back inline with CraueFormFlowBundle.

Also corrected form_actions->form-actions.
