### PR TITLE
badge and label macros

### DIFF
--- a/Resources/views/macros.html.twig
+++ b/Resources/views/macros.html.twig
@@ -1,9 +1,9 @@
 {% macro badge(text, type, use_raw) %}
-<span class="badge {{ type|default(false) ? 'badge-'~type: '' }}">{{ use_raw|default(false) ? text|trans|raw : text|trans }}</span>
+<span class="badge {{ type|default(false) ? 'badge-'~type: '' }}">{{ use_raw|default(false) ? text|raw : text }}</span>
 {% endmacro %}
 
 {% macro label(text, type, use_raw) %}
-<span class="label {{ type|default(false) ? 'label-'~type: '' }}">{{ use_raw|default(false) ? text|trans|raw : text|trans }}</span>
+<span class="label {{ type|default(false) ? 'label-'~type: '' }}">{{ use_raw|default(false) ? text|raw : text }}</span>
 {% endmacro %}
 
 


### PR DESCRIPTION
The variable `translation_domain` is not defined within the macro, unlike blocks, you cannot set variables within a macro without passing them, can you?

I also removed the `trans` filter.
The translation should be done outside of the macro and the passed text should be ready-to-use text, shouldn't it? - Did I miss something when using them?
