### PR TITLE
An expression regarding legends in the form template will always return false

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -344,7 +344,7 @@
     <div {% for attrname,attrvalue in widget_control_group_attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
     {# a form item containing the field in block_prefixes is a near subform or a field directly #}
     {% if (form.hasChildren() and form.hasParent())
-        and not 'field' in form.vars.block_prefixes %}
+        and 'field' not in form.vars.block_prefixes %}
         {% if show_child_legend%}
             {{ block('form_legend') }}
         {% endif %}


### PR DESCRIPTION
Moving the not keyword fixes this. See the following exanoke:

```
{% set test = [1,2] %}
{{ true and not 3 in test ? "True" : "False" }} {# Will result False #}
{{ true and 3 not in test ? "True" : "False" }} {# Will result True #}
```
