### PR TITLE
fix-for-collection-item-remove

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -54,7 +54,7 @@
         },
         remove: function () {
                 if (this.$element.parents('.collection-item').length !== 0){
-                    this.$element.parent('.collection-item').remove();
+                    this.$element.closest('.collection-item').remove();
                 }
         }
 


### PR DESCRIPTION
According to the jquery documentation 'parent' method will find only the first parent. If our collection-item is not exactly parent of a button (like in some div element) it will not remove the collection-item. The solution is - according to the 'closest' method documentation - to use: 
this.$element.closest('.collection-item').remove();
