### PR TITLE
Modified createDropdownMenuItem to support knp element options

### DIFF
--- a/Navbar/AbstractNavbarMenuBuilder.php
+++ b/Navbar/AbstractNavbarMenuBuilder.php
@@ -62,10 +62,13 @@ abstract class AbstractNavbarMenuBuilder
     /**
      * get a preconfigured Dropdown menu where to easily add childs
      *
+     * @param string  $rootItem      Parent item of the element
      * @param string  $title      Title of the item
      * @param boolean $push_right Make if float right default: true
+     * @param array $icon Icon definition options
+     * @param array $knp_item_options array of options for knp item element      
      */
-    protected function createDropdownMenuItem(ItemInterface $rootItem, $title, $push_right = true, $icon = array())
+    protected function createDropdownMenuItem(ItemInterface $rootItem, $title, $push_right = true, $icon = array(), $knp_item_options=array())
     {
         $rootItem
             ->setAttribute('class', 'nav')
@@ -73,7 +76,7 @@ abstract class AbstractNavbarMenuBuilder
         if ($push_right) {
             $this->pushRight($rootItem);
         }
-        $dropdown = $rootItem->addChild($title, array('uri'=>'#'))
+        $dropdown = $rootItem->addChild($title, array_merge($knp_item_options, array('uri'=>'#')))
             ->setLinkattribute('class', 'dropdown-toggle')
             ->setLinkattribute('data-toggle', 'dropdown')
             ->setAttribute('class', 'dropdown')
@@ -112,3 +115,4 @@ abstract class AbstractNavbarMenuBuilder
         ;
     }
 }
+


### PR DESCRIPTION
Hi,

 I find a problem trying to render dropdown menu in navbar without scape. If you want to make an item without scape, you can try something like this (using safe_label) :

$menu->addChild('Vehiculo',array('route' => 'txinbometro_vehiculo', 'label' => 'Veh&iacute;culo', 'extras'=>array('safe_label'=>true) ));

   But if you want to do the same thing in a dropdown, you can't access to knp menu item options. I propose to change createDropdownMenuItem function in AbstractNavbarMenuBuilder to add option parameters. I think if this function wraps a knp menu funciton, it must allow to access to knp options.

   I show an example of how to use it before and after the change:

BEFORE:

```
    $estadisticas=$this->createDropdownMenuItem($menu, 'Estadisticas' ); 
    $estadisticas->setLabel('Estad&iacute;sticas');
    $estadisticas->setExtras(array('safe_label'=>true) );
```

AFTER:

$estadisticas=$this->createDropdownMenuItem($menu, 'Estadisticas', true,array(),array('label'=>'Estad&iacute;sticas', 'extras'=>array('safe_label'=>true))); 

  By the way, I improve the PHPDoc in this function.

   Sorry for my english.
