### PR TITLE
Update Resources/doc/1-installation.md

### DIFF
--- a/Resources/doc/1-installation.md
+++ b/Resources/doc/1-installation.md
@@ -170,12 +170,12 @@ Installation
                    {
                        "type": "package",
                        "package": {
-                           "version": "master", /* whatever version you want */
+                           "version": "master", 
                            "name": "twitter/bootstrap",
                            "source": {
                                "url": "https://github.com/twitter/bootstrap.git",
                                "type": "git",
-                               "reference": "master"
+                               "reference": "master" /* whatever version you want */
                            },
                            "dist": {
                                "url": "https://github.com/twitter/bootstrap/zipball/master",


### PR DESCRIPTION
The "reference" : "master" is what is driving the version. "Version" is just for the "require" block to match. Confirmed by elnur : http://stackoverflow.com/questions/12627133
