### PR TITLE
Test vs latest Symfony versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,10 @@ language: php
 php:
   - 5.3
   # - 5.4
-  
+
 env:
-  #- SYMFONY_VERSION=v2.0.0
-  #- SYMFONY_VERSION=v2.0.1
-  # - SYMFONY_VERSION=v2.0.2 # broken tag
-  #- SYMFONY_VERSION=v2.0.3
-  #- SYMFONY_VERSION=v2.0.4
-  #- SYMFONY_VERSION=v2.0.5
-  - SYMFONY_VERSION=v2.0.6
+  - SYMFONY_VERSION=v2.0.17
+  - SYMFONY_VERSION=v2.1.0
   - SYMFONY_VERSION=origin/master
 
 before_script: php Tests/tests/vendors.php


### PR DESCRIPTION
Update `.travis.yml` to test vs the latest Symfony versions.

Not sure if we should test vs PHP 5.4 as well?
