### PR TITLE
Ask confirmation only if we are in interactive mode

### DIFF
--- a/Command/BootstrapSymlinkLessCommand.php
+++ b/Command/BootstrapSymlinkLessCommand.php
@@ -117,8 +117,10 @@ EOF
                 $this->getHelperSet()->get('formatter')->formatBlock($text, $style = 'bg=blue;fg=white', true),
                 '',
             ));
-            if (!$dialog->askConfirmation($this->output, '<question>Should this link be created? (y/n)</question>', false)) {
-                exit;
+            if ($this->input->isInteractive()) {
+                if (!$dialog->askConfirmation($this->output, '<question>Should this link be created? (y/n)</question>', false)) {
+                    exit;
+                }
             }
 
             return array($symlinkTarget, $symlinkName);

--- a/Command/BootstrapSymlinkSassCommand.php
+++ b/Command/BootstrapSymlinkSassCommand.php
@@ -117,8 +117,10 @@ EOF
                 $this->getHelperSet()->get('formatter')->formatBlock($text, $style = 'bg=blue;fg=white', true),
                 '',
             ));
-            if (!$dialog->askConfirmation($this->output, '<question>Should this link be created? (y/n)</question>', false)) {
-                exit;
+            if ($this->input->isInteractive()) {
+                if (!$dialog->askConfirmation($this->output, '<question>Should this link be created? (y/n)</question>', false)) {
+                    exit;
+                }
             }
 
             return array($symlinkTarget, $symlinkName);


### PR DESCRIPTION
Hi, 

Command should ask confirmation only if interactive mode is enabled (by default it is).

If you call `app/console .... --no-interaction` it should not and consider user know what he does.

Ex: If we want to deploy via capistrano, we'll not be able to confirm.
