### PR TITLE
Fix link to Bootstrap's LESS documentation

### DIFF
--- a/Resources/doc/less-installation.md
+++ b/Resources/doc/less-installation.md
@@ -4,7 +4,7 @@ MopaBootstrapBundle Less installation
 To effectively use all features of bootstrap you want to use less together with bootstrap.
 Have a look into the following docs what it is and then install it on your system.
 
- * [Twitters Less Doc](http://twitter.github.com/bootstrap/less.html)
+ * [Twitters Less Doc](http://twitter.github.com/bootstrap/extend.html)
  * [Lesscss](http://lesscss.org/)
 
 


### PR DESCRIPTION
This is the new location of the old page http://twitter.github.com/bootstrap/less.html

Although this new link is for Bootstrap 2.1, which may or may not have different documentation than their 2.0 release. And also I don't think MopaBootstrapBundle supports Bootstrap 2.1 yet. Regardless, the old link was broken.
