### PR TITLE
Don't ignore label_attr for extended choices and properly close input[type=checkbox] tags

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -66,7 +66,7 @@
 {% if form.hasParent() and 'choice' not in form.parent.vars.block_prefixes %}
     <label class="checkbox{% if inline is defined and inline %} inline{% endif %}">
 {% endif %}
-        <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}> {{ help_inline|trans({}, translation_domain)|raw }}
+        <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}/> {{ help_inline|trans({}, translation_domain)|raw }}
 {% if form.hasParent() and 'choice' not in form.parent.vars.block_prefixes %}
         {{ label|trans({}, translation_domain) }}
         {% set help_inline = false %}


### PR DESCRIPTION
`label_attr` was ignored in `choice_widget_expanded` and checkbox input tags were not properly closed (`<input>` instead of `<input/>`).

Do you want me to pull request this against the 2.0 branch or is master fine?
