### PR TITLE
Append the attr.class of a type to the control-group in collections

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -346,6 +346,9 @@
     {% if errors|length > 0 %}
         {% set widget_control_group_attr = widget_control_group_attr|merge({'class': widget_control_group_attr.class|default('') ~ ' error'}) %}
     {% endif %}
+	{% if 'collection' in form.vars.block_prefixes and attr.class is defined %}
+		{% set widget_control_group_attr = widget_control_group_attr|merge({'class': widget_control_group_attr.class|default('') ~ ' ' ~ attr.class}) %}
+	{% endif %}
     <div {% for attrname,attrvalue in widget_control_group_attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
     {# a form item containing the field in block_prefixes is a near subform or a field directly #}
     {% if (form.hasChildren() and form.hasParent())


### PR DESCRIPTION
Some people like me don't like to use the custom options introduced by MopaBootstrapBundle in order to not create a bundle dependency related to the design (if you change your design, leaving to use  Bootstrap and consequently removing the MopaBootstrapBundle for instance, you will need to refactor your code instead of just change the template or/and css files). 

Thus, I'm trying to use the standard Symfony options to do some things that already are made using the Mopa custom options.

In this first simple commit, I added the possibility to add a class to the control-group without need to use the widget_control_group_attr, in collections types.

I think it may be useful for someone.
