### PR TITLE
Closing label tag in choice_widget when label_render is false

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -67,9 +67,11 @@
     <label class="checkbox{% if inline is defined and inline %} inline{% endif %}">
 {% endif %}
         <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}/> {{ help_inline|trans({}, translation_domain)|raw }}
-{% if form.hasParent() and 'choice' not in form.parent.vars.block_prefixes and label_render %}
+{% if form.hasParent() and 'choice' not in form.parent.vars.block_prefixes %}
+    {% if label_render %}
         {{ label|trans({}, translation_domain) }}
-        {% set help_inline = false %}
+    {% endif %}
+    {% set help_inline = false %}
     </label>
 {% endif %}
 {% endspaceless %}


### PR DESCRIPTION
After merged pull request #351 option label_render works, but when label render is setted on false it doesn't close label tag.
