### PR TITLE
Fix default class on date_widget to be input-small

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -82,13 +82,13 @@
 {% if widget == 'single_text' %}
     {{ block('form_widget_simple') }}
 {% else %}
-        {% set attr = attr|merge({'class': attr.class|default('inline')}) %}
-            {{ date_pattern|replace({
-                '{{ year }}':  form_widget(form.year, {'attr': {'class': attr.widget_class|default('') ~ ' input-small'}}),
-                '{{ month }}': form_widget(form.month, {'attr': {'class': attr.widget_class|default('') ~ ' input-mini'}}),
-                '{{ day }}':   form_widget(form.day, {'attr': {'class': attr.widget_class|default('') ~ ' input-mini'}}),
-            })|raw }}
-        {{ block('help') }}
+    {% set attr = attr|merge({'class': attr.class|default('inline')}) %}
+        {{ date_pattern|replace({
+            '{{ year }}':  form_widget(form.year, {'attr': {'class': attr.widget_class|default('') ~ ' input-small'}}),
+            '{{ month }}': form_widget(form.month, {'attr': {'class': attr.widget_class|default('') ~ ' input-small'}}),
+            '{{ day }}':   form_widget(form.day, {'attr': {'class': attr.widget_class|default('') ~ ' input-small'}}),
+        })|raw }}
+    {{ block('help') }}
 {% endif %}
 {% endspaceless %}
 {% endblock date_widget %}


### PR DESCRIPTION
There was a previous commit (dd4e24324756fbb66ec2ae295cc6e49234ccce7b) which changed `input-mini` on the year to `input-small`, ~~but I'm not sure why it wasn't applied to each of the elements~~. (Edit: My mistake. `input-small` actually looks a lot better when you don't have extra CSS messing it up ;))

It looks like this without:

![Screen Shot 2013-01-15 at 14 37 45](https://f.cloud.github.com/assets/101828/67928/9ffef566-5f21-11e2-91cc-a7c7085db9be.png)

And this with this patch:

![Screen Shot 2013-01-15 at 14 38 09](https://f.cloud.github.com/assets/101828/67930/a8394f42-5f21-11e2-8b82-6982ad82bf37.png)
