### PR TITLE
Fixed removing of a collection item 

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -55,7 +55,7 @@
                 if (this.$element.parents('.collection-item').length !== 0){
                     var row = this.$element.closest('.collection-item');
                     row.remove();
-                    $(this.options.collection_id).trigger('remove.mopa-collection-item', [row]);
+                    //$(this.options.collection_id).trigger('remove.mopa-collection-item', [row]);
                 }
         }
 


### PR DESCRIPTION
The affected line leads to a removal of the entire collection 
including the label.

This is just a quick fix until the functionality has been revised.
Fixes #370
 
