### PR TITLE
Fix the link of the registration this bundle in doc

### DIFF
--- a/Resources/doc/1-installation.md
+++ b/Resources/doc/1-installation.md
@@ -160,7 +160,7 @@ Installation
     {
         return array(
             // ...
-            new Mopa\Bundle\BootstrapBundle\MopaBootstrapBundle(),
+            new Mopa\BootstrapBundle\MopaBootstrapBundle(),
             // ...
         );
     }
@@ -174,7 +174,7 @@ Installation
     {
         return array(
             // ...
-            new Mopa\Bundle\BootstrapBundle\MopaBootstrapBundle(),
+            new Mopa\BootstrapBundle\MopaBootstrapBundle(),
             new Knp\Bundle\MenuBundle\KnpMenuBundle(),
             new Knp\Bundle\PaginatorBundle\KnpPaginatorBundle(),
             new Craue\FormFlowBundle\CraueFormFlowBundle(),


### PR DESCRIPTION
To fix this error
`Fatal error: Class 'Mopa\Bundle\BootstrapBundle\MopaBootstrapBundle' not found in /var/www/investigation/app/AppKernel.php`

I have changed the link of the registration this bundle.
