### PR TITLE
Update jQuery version Resources/views/base.html.twig

### DIFF
--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -97,7 +97,7 @@
     Otherwise the regeneration is done on every load in dev more with use_controller: true
      #}
     {% javascripts
-        'http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js'
+        'http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js'
         '@MopaBootstrapBundle/Resources/bootstrap/js/bootstrap-transition.js'
         '@MopaBootstrapBundle/Resources/bootstrap/js/bootstrap-modal.js'
         '@MopaBootstrapBundle/Resources/bootstrap/js/bootstrap-dropdown.js'


### PR DESCRIPTION
Update jQuery version to match the bootstra official web site
The current version on the official web site is the 1.8.2 whereas current one is 1.7.1.
