### PR TITLE
fixed sortable_link.html.twig not having quotes

### DIFF
--- a/Resources/views/Pagination/sortable_link.html.twig
+++ b/Resources/views/Pagination/sortable_link.html.twig
@@ -1,6 +1,6 @@
 {% set link = "" %}
 {% for attr, value in options %}
-    {% set link = link ~ " " ~ attr ~ "=" ~ value %}
+    {% set link = link ~ " " ~ attr ~ '="' ~ value~ '"' %}
 {% endfor %}
 
 <a {{ link }}>{{ title }}</a>


### PR DESCRIPTION
The href generated in sortable_link.html.twig was unquoted.
