### PR TITLE
Fixed deprecated twig calls in fields.html.twig

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -68,6 +68,7 @@
 {% endif %}
         <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}/> {{ help_inline|trans({}, translation_domain)|raw }}
 {% if form.parent is not null and 'choice' not in form.parent.vars.block_prefixes and label_render %}
+    {% if label_render %}
         {{ label|trans({}, translation_domain) }}
     {% endif %}
     {% set help_inline = false %}


### PR DESCRIPTION
Replaced form.hasParent with a check on form.parent and hasChilden
with form.count 

See #361 for more info
