### PR TITLE
datepicker.less comile error problem

### DIFF
--- a/Resources/public/less/datepicker.less
+++ b/Resources/public/less/datepicker.less
@@ -6,7 +6,10 @@
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  */
- 
+// Core variables and mixins
+@import "../../bootstrap/less/variables.less";
+@import "../../bootstrap/less/mixins.less";
+
 .datepicker {
 	top: 0;
 	left: 0;


### PR DESCRIPTION
The datepicker.less is not compiling due to the fact that it has no access to the variables.less and mixins.less files. This is because it is imported after the mopabootstrapbundle.less file in the base.html.twig template, and therefore is separately compiled.
I have imported the two necessary files directly into the datepicker.less file so as to avoid errors on compilation.
