### PR TITLE
Checkbox label

### DIFF
--- a/Form/Extension/WidgetFormTypeExtension.php
+++ b/Form/Extension/WidgetFormTypeExtension.php
@@ -38,6 +38,7 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
         $view->vars['widget_type'] = $options['widget_type'];
         $view->vars['widget_control_group_attr'] = $options['widget_control_group_attr'];
         $view->vars['widget_controls_attr'] = $options['widget_controls_attr'];
+        $view->vars['widget_checkbox_label'] = $options['widget_checkbox_label']; 
 
     }
     public function setDefaultOptions(OptionsResolverInterface $resolver)
@@ -56,12 +57,18 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
                 'widget_type' => '',
                 'widget_control_group_attr' => array(),
                 'widget_controls_attr' => array(),
+                'widget_checkbox_label' => 'both', 
             )
         );
         $resolver->setAllowedValues(array(
                 'widget_type' => array(
                     'inline',
                     '',
+                ), 
+                'widget_checkbox_label' => array(
+                    'label', 
+                    'widget', 
+                    'both', 
                 )
             )
         );

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -68,7 +68,7 @@
 {% endif %}
         <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}/> {{ help_inline|trans({}, translation_domain)|raw }}
 {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
-    {% if label_render %}
+    {% if label_render and widget_checkbox_label in ['both', 'widget'] %}
         {{ label|trans({}, translation_domain) }}
     {% endif %}
     {% set help_inline = false %}
@@ -172,6 +172,7 @@
 {% endblock form_legend %}
 
 {% block form_label %}
+{% if 'checkbox' not in block_prefixes or widget_checkbox_label in ['label', 'both'] %}
 {% spaceless %}
     {% if label is not sameas(false) %}
         {% if label is empty %}
@@ -196,6 +197,7 @@
         </label>
     {% endif %}
 {% endspaceless %}
+{% endif %}
 {% endblock form_label %}
 
 {% block help_label %}


### PR DESCRIPTION
Issue: https://github.com/phiamo/MopaBootstrapBundle/issues/369

I think this should do it pretty simply. Not really much changed, just added a new option to the form extension called widget_checkbox_label and you can give it values 'label', 'widget', or 'both.' If you think it belongs in another extension I can move it - The option also defaults to 'both' so there shouldn't be any BC breaks. 
