### PR TITLE
make navbar title overwritable by twig call

### DIFF
--- a/Resources/views/Navbar/navbar.html.twig
+++ b/Resources/views/Navbar/navbar.html.twig
@@ -7,7 +7,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </a>
-            {% if navbar.hasOption('title') %}<a class="brand" href="{{ path(navbar.getOption('titleRoute')) }}">{{ navbar.getOption('title') }}</a>{% endif %}
+            {% if navbar.hasOption('title') %}<a class="brand" href="{{ path(navbar.getOption('titleRoute')) }}">{{ options.title|default(navbar.getOption('title')) }}</a>{% endif %}
             <div class="nav-collapse">
                 {{ navbar.hasMenu('leftmenu') ? knp_menu_render(navbar.getMenu('leftmenu'), {'currentClass': 'active', 'ancestorClass': 'active', 'allow_safe_labels': 'true'}) : '' }}
                 {% if navbar.hasFormView('searchform') %}


### PR DESCRIPTION
Regarding #404, i've created the possibility to overwrite the title of a navbar by calling 

```
{{ mopa_bootstrap_navbar('my.custom.navbar', {'title': 'my-site.com'}) }}
```

"at runtime", e.g. from the site template. I know this is not perfect, but may be a useful workaround atm.
