### PR TITLE
fix collection remove event

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -46,7 +46,7 @@
             this.addPrototype(index);
         },
         addPrototype: function(index) {
-            var rowContent = $(this.options.collection_id).attr('data-prototype').replace(/__name__/g, index);            
+            var rowContent = $(this.options.collection_id).attr('data-prototype').replace(/__name__/g, index);
             var row = $(rowContent);     
             $('div' + this.options.collection_id + '> .controls').append(row);
             $(this.options.collection_id).trigger('add.mopa-collection-item', [row]);
@@ -55,7 +55,7 @@
                 if (this.$element.parents('.collection-item').length !== 0){
                     var row = this.$element.closest('.collection-item');
                     row.remove();
-                    $(this.options.collection_id).trigger('remove.mopa-collection-item', [row]);
+                    $(this.options.collection_id).triggerHandler('remove.mopa-collection-item', [row]);
                 }
         }
 


### PR DESCRIPTION
dispatch `remove.mopa-collection-item` with `triggerHandler` rather than `trigger` to prevent removal of the whole collection. from jQuery docs:

> Note: For both plain objects and DOM objects, if a triggered event name matches the name of a property on the object, jQuery will attempt to invoke the property as a method if no event handler calls event.preventDefault(). If this behavior is not desired, use .triggerHandler() instead.

because events dispatched with `triggerHandler` don't bubble, one needs to listen for this event on the collection control group.
