### PR TITLE
fixing missing globals problem in twig, closes #360

### DIFF
--- a/Navbar/Renderer/NavbarRenderer.php
+++ b/Navbar/Renderer/NavbarRenderer.php
@@ -46,7 +46,7 @@ class NavbarRenderer
 
         // we do not call renderBlock here to avoid too many nested level calls (XDebug limits the level to 100 by default)
         ob_start();
-        $template->displayBlock($block, array('navbar' => $navbar, 'options' => $options));
+        $template->displayBlock($block, array_merge($template->getEnvironment()->getGlobals() ,array('navbar' => $navbar, 'options' => $options)));
         $html = ob_get_clean();
 
         return $html;


### PR DESCRIPTION
With Symfony 2.2, the globals are gone in twig theme context, so we have to pass them.

Twig Exception:
"Variable "app" does not exist in" navbar template context

references:
https://github.com/symfony/symfony/issues/3058
closes:
https://github.com/phiamo/MopaBootstrapBundle/issues/360
