### PR TITLE
Duplicate Error Blocks for Collections

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -223,11 +223,6 @@
 
 {% block form_rows_visible %}
 {% spaceless %}
-    {% if form_errors(form) %}
-        <div class="symfony-form-errors">
-            {{ form_errors(form) }}
-        </div>
-    {% endif %}
     {% for child in form %}
         {% if 'hidden' not in child.vars.block_prefixes %}
             {% if 'collection' in form.vars.block_prefixes and not omit_collection_item %}


### PR DESCRIPTION
Removed additional error block which causes duplicate error messages as seen in the following screenshot.

![Bildschirmfoto 2013-04-25 um 08 49 38](https://f.cloud.github.com/assets/2010989/423888/a4ac09ae-ad74-11e2-824d-ef9df3364d1c.png)
