### PR TITLE
Added missing semicolon

### DIFF
--- a/Resources/public/js/eyecon-bootstrap-datepicker.js
+++ b/Resources/public/js/eyecon-bootstrap-datepicker.js
@@ -451,4 +451,4 @@
 							'</div>'+
 						'</div>';
 
-}( window.jQuery )
+}( window.jQuery );


### PR DESCRIPTION
This missing semicolon prevents Assetic from correctly merging JS files.
