### PR TITLE
fixed NavbarRenderer.php not accepting a menu object 

### DIFF
--- a/Navbar/Renderer/NavbarRenderer.php
+++ b/Navbar/Renderer/NavbarRenderer.php
@@ -21,17 +21,17 @@ class NavbarRenderer
     /**
      * Renders the navbar with the specified renderer.
      *
-     * @param  ItemInterface|string $name
+     * @param  ItemInterface|string $navbar
      * @param  array                $options
      * 
      * @return string
      */
-    public function renderNavbar($name, array $options = array())
+    public function renderNavbar($navbar, array $options = array())
     {
         $options = array_merge($this->getNavbarDefaultOptions(), $options);
         
-        if (!$name instanceof ItemInterface) {
-             $navbar = $this->getNavbar($name);           
+        if (!$navbar instanceof ItemInterface) {
+             $navbar = $this->getNavbar($navbar);           
         }
 
         $navbar = $this->createFormViews($navbar);


### PR DESCRIPTION
NavbarRenderer::renderNavbar() always looked-up the menu even when it was already an object.
