### PR TITLE
Ignore help tooltips from the tab order

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -209,7 +209,7 @@
 
 {% block help_label_tooltip_title %}
     <p class="help-inline">
-        <a href="#" id="{{ id }}" title="{{ help_label_tooltip_title|trans({}, translation_domain) }}"><i class="icon-info-sign"></i></a>
+        <a href="#" id="{{ id }}" title="{{ help_label_tooltip_title|trans({}, translation_domain) }}" tabindex="-1"><i class="icon-info-sign"></i></a>
         <script type="text/javascript">
             $(document).ready(function () {
                 $({{ id }}).tooltip({


### PR DESCRIPTION
Added tabindex="-1" to the help tooltip in order to ignore them in
the tabindex.

This is supported in Chrome 23, Firefox 18, IE8, IE9, and Opera 12.11
