### PR TITLE
fixed logic in checkbox widget

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -72,7 +72,9 @@
         {{ label|trans({}, translation_domain) }}
     {% endif %}
     {% set help_inline = false %}
+    {% if label_render %}
     </label>
+    {% endif %}
 {% endif %}
 {% endspaceless %}
 {% endblock checkbox_widget %}


### PR DESCRIPTION
There was a logical case where a <label> element could have been closed but not opened within the checkbox widget - this change fixes this.
