### PR TITLE
Conditional tag for X-UA-Compatible

### DIFF
--- a/Resources/views/base_initializr.html.twig
+++ b/Resources/views/base_initializr.html.twig
@@ -29,7 +29,7 @@
        X-UA-Compatible meta element, which will prompt them to switch to Desktop Mode.
        http://html5boilerplate.com/docs/html-head/#prompt-users-to-switch-to-desktop-mode-in-ie10-metro
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1,requiresActiveX=true"> #}
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /><![endif]-->
 
     {# WARNING: do not add "initial-scale=1" to viewport, breaks iOS view!
        https://github.com/h5bp/html5-boilerplate/issues/824 #}


### PR DESCRIPTION
Please insert <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /> into conditional tag, because its not validate for HTML validator, thx

http://stackoverflow.com/questions/14198594/bad-value-x-ua-compatible-for-attribute-http-equiv-on-element-meta
