### PR TITLE
Configuration fix for fatal error - arguments must be passed as arrays for form extensions

### DIFF
--- a/Resources/config/form_extensions.yml
+++ b/Resources/config/form_extensions.yml
@@ -1,36 +1,31 @@
 services:
     mopa.form.help_extension:
            class: Mopa\Bundle\BootstrapBundle\Form\Extension\HelpFormTypeExtension
-           arguments:
-                - { tooltip_icon: %mopa_bootstrap.form.tooltip.icon%, tooltip_placement: %mopa_bootstrap.form.tooltip.placement%, popover_icon: %mopa_bootstrap.form.popover.icon%, popover_placement: %mopa_bootstrap.form.popover.placement%}
+           arguments: { tooltip_icon: %mopa_bootstrap.form.tooltip.icon%, tooltip_placement: %mopa_bootstrap.form.tooltip.placement%, popover_icon: %mopa_bootstrap.form.popover.icon%, popover_placement: %mopa_bootstrap.form.popover.placement%}
            tags:
                 - { name: form.type_extension, alias: form }
 
     mopa.form.legend_extension:
            class: Mopa\Bundle\BootstrapBundle\Form\Extension\LegendFormTypeExtension
-           arguments:
-                - { render_fieldset: %mopa_bootstrap.form.render_fieldset%, show_legend: %mopa_bootstrap.form.show_legend%, show_child_legend: %mopa_bootstrap.form.show_child_legend%, render_required_asterisk: %mopa_bootstrap.form.render_required_asterisk%, render_optional_text: %mopa_bootstrap.form.render_optional_text%, errors_on_forms: %mopa_bootstrap.form.errors_on_forms% }
+           arguments: { render_fieldset: %mopa_bootstrap.form.render_fieldset%, show_legend: %mopa_bootstrap.form.show_legend%, show_child_legend: %mopa_bootstrap.form.show_child_legend%, render_required_asterisk: %mopa_bootstrap.form.render_required_asterisk%, render_optional_text: %mopa_bootstrap.form.render_optional_text%, errors_on_forms: %mopa_bootstrap.form.errors_on_forms% }
            tags:
                 - { name: form.type_extension, alias: form }
 
     mopa.form.error_type_extension:
            class: Mopa\Bundle\BootstrapBundle\Form\Extension\ErrorTypeFormTypeExtension
-           arguments:
-                - { error_type: %mopa_bootstrap.form.error_type% }
+           arguments: { error_type: %mopa_bootstrap.form.error_type% }
            tags:
                 - { name: form.type_extension, alias: form }
 
     mopa.form.widget_extension:
            class: Mopa\Bundle\BootstrapBundle\Form\Extension\WidgetFormTypeExtension
-           arguments:
-                - { checkbox_label: %mopa_bootstrap.form.checkbox_label% }
+           arguments: { checkbox_label: %mopa_bootstrap.form.checkbox_label% }
            tags:
                 - { name: form.type_extension, alias: form }
 
     mopa.form.widget_collection_extension:
            class: Mopa\Bundle\BootstrapBundle\Form\Extension\WidgetCollectionFormTypeExtension
-           arguments:
-                - { widget_add_btn: %mopa_bootstrap.form.collection.widget_add_btn%, widget_remove_btn: %mopa_bootstrap.form.collection.widget_remove_btn% }
+           arguments: { widget_add_btn: %mopa_bootstrap.form.collection.widget_add_btn%, widget_remove_btn: %mopa_bootstrap.form.collection.widget_remove_btn% }
            tags:
                 - { name: form.type_extension, alias: form }
     mopa.form.date_extension:


### PR DESCRIPTION
The arguments for the form extensions must be passed as arrays because the respective classes are type-hinted and are expecting arrays, so I have corrected the configuration file to define the arguments correctly.
