### PR TITLE
fallback to default icon_color in collection buttons

### DIFF
--- a/Form/Extension/WidgetCollectionFormTypeExtension.php
+++ b/Form/Extension/WidgetCollectionFormTypeExtension.php
@@ -34,6 +34,9 @@ class WidgetCollectionFormTypeExtension extends AbstractTypeExtension
             if (!isset($options['widget_add_btn']['icon']) && $this->options['widget_add_btn']['icon'] != null) {
                 $options['widget_add_btn']['icon'] = $this->options['widget_add_btn']['icon'];
             }
+            if (!isset($options['widget_add_btn']['icon_color']) && isset($this->options['widget_add_btn']['icon_color'])) {
+                $options['widget_add_btn']['icon_color'] = $this->options['widget_add_btn']['icon_color'];
+            }
         }
         if ($options['widget_remove_btn'] != null && !is_array($options['widget_remove_btn'])) {
                 throw new UnexpectedTypeException($options['widget_remove_btn'], "array");


### PR DESCRIPTION
I think in the `WidgetCollectionFormTypeExtension` the default `icon_color`, which could be defined in the config.yml, is not used as fallback.

Please insert this patch into branch v2.2.x (and apply to master, too).
Thanks :-)
