### PR TITLE
No "widget label" on checkbox if there is no custom label

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -63,6 +63,9 @@
 
 {% block checkbox_widget %}
 {% spaceless %}
+{% if label is not sameas(false) and label is empty %}
+    {% set label = name|humanize %}
+{% endif %}
 {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes and label_render %}
     <label class="checkbox{% if inline is defined and inline %} inline{% endif %}">
 {% endif %}


### PR DESCRIPTION
There is no widget label for checkboxes without a custom label (and no label at all if `widget_checkbox_label` is set to `widget`)
