### PR TITLE
Fixed unexpected collection removal in Chrome

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -66,13 +66,13 @@
             var rowContent = $el.attr('data-prototype').replace(replace_pattern, index);
             var row = $(rowContent);
             $('div' + this.options.collection_id + '> .controls').append(row);
-            $(this.options.collection_id).trigger('add.mopa-collection-item', [row]);
+            $(this.options.collection_id).triggerHandler('add.mopa-collection-item', [row]);
         },
         remove: function () {
                 if (this.$element.parents('.collection-item').length !== 0){
                     var row = this.$element.closest('.collection-item');
                     row.remove();
-                    $(this.options.collection_id).trigger('remove.mopa-collection-item', [row]);
+                    $(this.options.collection_id).triggerHandler('remove.mopa-collection-item', [row]);
                 }
         }
 


### PR DESCRIPTION
The usage of trigger() leads to the removal of the entire collection area in Chrome on Mac.
Firefox does not behave unexpectedly. 

If the event is named any different than remove.mopa-collection everything works.
