### PR TITLE
Added id and class option to collection items

### DIFF
--- a/Form/Extension/WidgetFormTypeExtension.php
+++ b/Form/Extension/WidgetFormTypeExtension.php
@@ -15,7 +15,7 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
     {
         $this->options = $options;
     }
-    
+
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         if (!is_array($options['widget_addon'])) {
@@ -42,9 +42,10 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
         $view->vars['widget_prefix'] = $options['widget_prefix'];
         $view->vars['widget_suffix'] = $options['widget_suffix'];
         $view->vars['widget_type'] = $options['widget_type'];
+        $view->vars['widget_items_attr'] = $options['widget_items_attr'];
         $view->vars['widget_control_group_attr'] = $options['widget_control_group_attr'];
         $view->vars['widget_controls_attr'] = $options['widget_controls_attr'];
-        $view->vars['widget_checkbox_label'] = $options['widget_checkbox_label']; 
+        $view->vars['widget_checkbox_label'] = $options['widget_checkbox_label'];
 
     }
     public function setDefaultOptions(OptionsResolverInterface $resolver)
@@ -61,20 +62,21 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
                 'widget_prefix' => null,
                 'widget_suffix' => null,
                 'widget_type' => '',
+                'widget_items_attr' => array(),
                 'widget_control_group_attr' => array(),
                 'widget_controls_attr' => array(),
-                'widget_checkbox_label' => $this->options['checkbox_label'], 
+                'widget_checkbox_label' => $this->options['checkbox_label'],
             )
         );
         $resolver->setAllowedValues(array(
                 'widget_type' => array(
                     'inline',
                     '',
-                ), 
+                ),
                 'widget_checkbox_label' => array(
-                    'label', 
-                    'widget', 
-                    'both', 
+                    'label',
+                    'widget',
+                    'both',
                 )
             )
         );

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -241,7 +241,7 @@
     {% for child in form %}
         {% if 'hidden' not in child.vars.block_prefixes %}
             {% if 'collection' in form.vars.block_prefixes and not omit_collection_item %}
-            <div class="collection-item" {% if child.vars.id is not empty %}id="{{ child.vars.id }}" {% endif %}>
+            <div class="collection-item {{ widget_items_attr.class|default()|join(' ') }}" id="{{ child.vars.id }}_control_group">
             {% endif %}
             {{ form_row(child) }}
             {% if 'collection' in form.vars.block_prefixes and not omit_collection_item %}
@@ -404,7 +404,7 @@
 {% spaceless %}
 {% if widget_control_group|default(false) or form.parent == null %}
     {% if prototype is defined %}
-        {% set data_prototype = 'collection' in form.vars.block_prefixes and not omit_collection_item ? '<div class="collection-item" id="' ~ prototype.vars.id ~ '">' ~ form_row(prototype) ~ '</div>' : form_row(prototype) %}
+        {% set data_prototype = 'collection' in form.vars.block_prefixes and not omit_collection_item ? '<div class="collection-item ' ~ widget_items_attr.class|default()|join(' ') ~ '" id="' ~ prototype.vars.id ~ '_control_group">' ~ form_row(prototype) ~ '</div>' : form_row(prototype) %}
         {% set data_prototype_name = form.vars.form.vars.prototype.vars.name|default('__name__') %}
         {% set widget_control_group_attr = widget_control_group_attr|merge({'data-prototype': data_prototype, 'data-prototype-name': data_prototype_name}) %}
     {% endif %}


### PR DESCRIPTION
In order to be able to have tabable collections there is the need for a collection-item id and the need for classes
to be added to a collection.

If you want to have tabs you can get to this with the following javascript code.

``` javascript
$(document).ready(function () {
    updateCollectionTabs('init');
});

$('#vendor_corebundle_formtype_collection_control_group').on('add.mopa-collection-item', function(e, row) {
    updateCollectionTabs('add', row[0]);
});

$('#vendor_corebundle_formtype_collection_control_group').on('remove.mopa-collection-item', function(e, row) {
    updateCollectionTabs('remove', row[0]);
});

function updateCollectionTabs(type, row)
{
    $('#CollectionTabs').empty();
    $('#vendor_corebundle_formtype_collection_control_group .collection-item').each(function(index, value) {
        $('#CollectionTabs').append('<li><a href="#' + value.id + '" data-toggle="tab"> #' + (index + 1) + '</a></li>');
    });

    switch(type) {
        case 'add':
            $('#CollectionTabs a[href="#' + row.id + '"]').tab('show');
            break;
        case 'remove':
        default:
            $('#CollectionTabs a:first').tab('show');
            break;
    }
}
```

In addition to that you need to set the following options in the form builder:

``` php
            $builder->add(
                'collection',
                'collection',
                array(
                    'widget_controls_attr' => array(
                        'class' => 'tab-content',
                    ),
                    'widget_items_attr' => array(
                        'class' => 'tab-pane',
                    )
                )
            )
```

And last but not least an empty ul container in the template:

``` html
            <ul id="CollectionTabs" class="nav nav-tabs"></ul>
```

Based on the preparation you can adjust this to your needs.
