### PR TITLE
Added ButtonFormType to allow the usage of icons in buttons

### DIFF
--- a/Form/Extension/IconButtonExtension.php
+++ b/Form/Extension/IconButtonExtension.php
@@ -1,0 +1,40 @@
+<?php
+namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
+
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
+
+class IconButtonExtension extends AbstractTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return 'button';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(
+            array(
+                'icon' => null
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['icon'] = $options['icon'];
+    }
+}

--- a/Resources/config/form_extensions.yml
+++ b/Resources/config/form_extensions.yml
@@ -1,4 +1,9 @@
 services:
+    mopa.form.icon_button_extension:
+           class: Mopa\Bundle\BootstrapBundle\Form\Extension\IconButtonExtension
+           tags:
+               - { name: form.type_extension, alias: button }
+
     mopa.form.help_extension:
            class: Mopa\Bundle\BootstrapBundle\Form\Extension\HelpFormTypeExtension
            arguments:

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -7,6 +7,16 @@
     {{ parent() }}
 {% endblock button_attributes %}
 
+{% block button_widget %}
+{% spaceless %}
+    {% if label is empty %}
+        {% set label = name|humanize %}
+    {% endif %}
+    <button type="{{ type|default('button') }}" {{ block('button_attributes') }}>
+    {% if icon is not empty %} <i class="icon-{{ icon }}"></i> {% endif %} {{ label|trans({}, translation_domain) }}</button>
+{% endspaceless %}
+{% endblock button_widget %}
+
 {# Widgets #}
 
 {% block form_widget_simple %}


### PR DESCRIPTION
Hi,

i extended the button type to allow the usage of FontAwesome/Glyphicons in buttons generated by the form component..
Usage:

```
class CertifierType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder

        ...

            ->add(
                'save',
                'submit',
                [
                    'label' => 'certifier.form.save',
                    'icon'  => 'save'
                ]
            );
    }

    ...

}
```

results in something like

```
<button class="btn" name="mcl_entrycertificate_webbundle_shipmenttype[save]" id="mcl_entrycertificate_webbundle_shipmenttype_save" type="submit">
    <i class="icon-save"></i>  Speichern
</button>
```
