### PR TITLE
Update BaseBootstrapSymlinkCommand.php

### DIFF
--- a/Command/BaseBootstrapSymlinkCommand.php
+++ b/Command/BaseBootstrapSymlinkCommand.php
@@ -57,7 +57,8 @@ abstract class BaseBootstrapSymlinkCommand extends ContainerAwareCommand
             return;
         }
 
-        if ($input->getOption('no-symlink')) {
+        // Automatically detect if on Win XP where symlink will allways fail
+        if ($input->getOption('no-symlink') or PHP_OS=="WINNT")  {
             $this->output->write("Checking destination");
 
             if (true === self::checkSymlink($symlinkTarget, $symlinkName)) {


### PR DESCRIPTION
I am on Win XP and if I run the Script without a parameter it will allways fail. Unfortunaltely you can't pass parameters to scripts via the composer.json, so I think this solution isn't that bad?
