### PR TITLE
Correct twitter bootstrap package name

### DIFF
--- a/Command/BootstrapSymlinkLessCommand.php
+++ b/Command/BootstrapSymlinkLessCommand.php
@@ -8,7 +8,7 @@ namespace Mopa\Bundle\BootstrapBundle\Command;
 class BootstrapSymlinkLessCommand extends BaseBootstrapSymlinkCommand
 {
     public static $mopaBootstrapBundleName = "mopa/bootstrap-bundle";
-    public static $twitterBootstrapName = "twbs/bootstrap";
+    public static $twitterBootstrapName = "twitter/bootstrap";
     
     protected function getTwitterBootstrapName(){
         return self::$twitterBootstrapName;


### PR DESCRIPTION
Correct [twitter/bootstrap](https://packagist.org/packages/twitter/bootstrap) name (the repo changed but the name still staying the same)
