### PR TITLE
Display asterisk on checkbox widget

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -89,6 +89,9 @@
 {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
     {% if label_render and widget_checkbox_label in ['both', 'widget'] %}
         {{ label|trans({}, translation_domain) }}
+        {% if widget_checkbox_label == 'widget' %}
+            {{ block('label_asterisk') }}
+        {% endif %}
     {% endif %}
     {% set help_inline = false %}
     {% if label_render %}


### PR DESCRIPTION
If the option `mopa_bootstrap.form.checkbox_label` is set at `widget`
when `mopa_bootstrap.form.render_required_asterisk` is `true`, asterisk
is not display, so I add it.
