### PR TITLE
Added widget_addon to choice_widget_collapsed

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -77,6 +77,31 @@
 {% endspaceless %}
 {% endblock choice_widget_expanded %}
 
+{% block choice_widget_collapsed %}
+    {% spaceless %}
+        {% if widget_addon.type == 'prepend' %}
+            {{ block('widget_addon') }}
+        {% endif %}
+        <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
+            {% if empty_value is not none %}
+                <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ empty_value|trans({}, translation_domain) }}</option>
+            {% endif %}
+            {% if preferred_choices|length > 0 %}
+                {% set options = preferred_choices %}
+                {{ block('choice_widget_options') }}
+                {% if choices|length > 0 and separator is not none %}
+                    <option disabled="disabled">{{ separator }}</option>
+                {% endif %}
+            {% endif %}
+            {% set options = choices %}
+            {{ block('choice_widget_options') }}
+        </select>
+        {% if widget_addon.type == 'append' %}
+            {{ block('widget_addon') }}
+        {% endif %}
+    {% endspaceless %}
+{% endblock choice_widget_collapsed %}
+
 {% block checkbox_widget %}
 {% spaceless %}
 {% if label is not sameas(false) and label is empty %}


### PR DESCRIPTION
Added widget_addon to the choice field in order to make content before or after the <select> field possible.
With this change for example a button after the field is possible.

![bildschirmfoto 2013-08-27 um 10 02 40](https://f.cloud.github.com/assets/2010989/1031879/115d06b2-0eef-11e3-964c-cd9f69e02d7f.png)
