### PR TITLE
Use navbar-default as default for navbar-bs3

### DIFF
--- a/Resources/views/Navbar/navbar_bs_3.html.twig
+++ b/Resources/views/Navbar/navbar_bs_3.html.twig
@@ -1,5 +1,5 @@
 {% block navbar %}
-<div class="navbar{{ (navbar.hasOption('inverse') and  navbar.getOption('inverse')) ? ' navbar-inverse' : '' }}{{ (navbar.hasOption('fixedTop') and  navbar.getOption('fixedTop')) ? ' navbar-fixed-top' : '' }}{{ (navbar.hasOption('staticTop') and  navbar.getOption('staticTop')) ? ' navbar-static-top' : '' }}">
+<div class="navbar{{ (navbar.hasOption('inverse') and navbar.getOption('inverse')) ? ' navbar-inverse' : ' navbar-default' }}{{ (navbar.hasOption('fixedTop') and navbar.getOption('fixedTop')) ? ' navbar-fixed-top' : '' }}{{ (navbar.hasOption('staticTop') and navbar.getOption('staticTop')) ? ' navbar-static-top' : '' }}">
     <div class="container">
         <div class="navbar-header">
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse" >


### PR DESCRIPTION
Bootstrap 3 has new class navbar-default for regular (white) navbar,
this should be used when not using inversed (black) navbar.
