### PR TITLE
[BS2][BS3] Allow to add a class to a textarea

### DIFF
--- a/Resources/views/Form/fields_bs_2.html.twig
+++ b/Resources/views/Form/fields_bs_2.html.twig
@@ -20,7 +20,7 @@
 {# Widgets #}
 
 {% block textarea_widget %}
-{% set attr = attr|merge({'class': 'form-control'}) %}
+{% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
 {{ parent() }}
 {% endblock textarea_widget %}
 

--- a/Resources/views/Form/fields_bs_3.html.twig
+++ b/Resources/views/Form/fields_bs_3.html.twig
@@ -25,7 +25,7 @@
 {% endblock choice_widget_collapsed %}
 
 {% block textarea_widget %}
-{% set attr = attr|merge({'class': 'form-control'}) %}
+{% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
 {{ parent() }}
 {% endblock textarea_widget %}
 


### PR DESCRIPTION
Type: Feature
BC break: NO

Currently, it is not possible to add a custom class to a textarea widget, this fixes it.
