### PR TITLE
Added correct version string for bundle branch 2.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want to use bootstrap 2:
 
 {
     "require": {
-        "mopa/bootstrap-bundle": "dev-v2.3.x",
+        "mopa/bootstrap-bundle": "2.3.x-dev",
         "twbs/bootstrap": "v2.3.2"
     }
 }


### PR DESCRIPTION
Used version string from https://packagist.org/packages/mopa/bootstrap-bundle
The current version produces this error:

```
  Problem 1
    - The requested package mopa/bootstrap-bundle dev-v2.3.x could not be found.
```
