### PR TITLE
base_initializr.html.twig fix for 2.3.x branch

### DIFF
--- a/Resources/views/base_initializr.html.twig
+++ b/Resources/views/base_initializr.html.twig
@@ -179,7 +179,7 @@
         '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-subnav.js'
         '@MopaBootstrapBundle/Resources/public/js/html5bp_plugins.js'
         '@MopaBootstrapBundle/Resources/public/js/html5bp_script.js'
-        '@MopaBootstrapBundle/Resources/public/js/eyecon-bootstrap-3-datepicker.js'
+        '@MopaBootstrapBundle/Resources/public/js/eyecon-bootstrap-datepicker.js'
         output='js/foot_compiled.js'
     %}
     <script type="text/javascript" src="{{ asset_url }}"></script>


### PR DESCRIPTION
base_initializr.html.twig was fixed for 2.3.x branch and uses bootstrap 2 javascript files
