### PR TITLE
Update config `form.row_wrapper_class` default value to prevent a row/col bug

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -63,7 +63,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue("col-lg-9")
                             ->end()
                         ->scalarNode('row_wrapper_class')
-                            ->defaultValue('form-group')
+                            ->defaultValue('form-group row')
                             ->end()
                         ->booleanNode('render_fieldset')
                             ->defaultValue(true)


### PR DESCRIPTION
With the previous configuration, `{{ form_row(form.field) }}` (for a "horizontal" form) was generating several `col-*-*` without a `row` to wrap them around. This was causing weird layout bugs.
