### PR TITLE
Show errors in tabs and set first tab with error to be active.

### DIFF
--- a/Form/Extension/TabbedFormTypeExtension.php
+++ b/Form/Extension/TabbedFormTypeExtension.php
@@ -48,22 +48,35 @@ class TabbedFormTypeExtension extends AbstractTypeExtension
             return;
         }
 
-        $found_first = false;
+        $activeTab = null;
+        $tabIndex = 0;
+        $foundInvalid = false;
         $tabs = array();
 
         foreach($view->children as $child) {
             if(in_array('tab', $child->vars['block_prefixes'])) {
-                if (!$found_first) {
-                    $child->vars['tab_active'] = $found_first = true;
+
+                $child->vars['tab_index'] = $tabIndex;
+                $valid = $child->vars['valid'];
+
+                if (($activeTab === null || !$valid) && !$foundInvalid) {
+                    $activeTab = $child;
+                    $foundInvalid = !$valid;
                 }
 
-                $tabs[] = array(
+                $tabs[$tabIndex] = array(
                     'id' => $child->vars['id'],
                     'label' => $child->vars['label'],
                     'icon' => $child->vars['icon'],
+                    'active' => false,
                 );
+
+                $tabIndex++;
             }
         }
+
+        $activeTab->vars['tab_active'] = true;
+        $tabs[$activeTab->vars['tab_index']]['active'] = true;
 
         $tabsForm = $this->formFactory->create(new TabsType(), null, array(
             'tabs' => $tabs,

--- a/Form/Type/TabType.php
+++ b/Form/Type/TabType.php
@@ -13,14 +13,16 @@ class TabType extends AbstractType
     {
         $resolver->setDefaults(array(
             'icon' => null,
+            'error_icon' => 'remove-sign',
         ));
     }
 
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['icon'] = $options['icon'];
+        $view->vars['valid'] = $valid = !$form->isSubmitted() || $form->isValid();
+        $view->vars['icon'] = $valid ? $options['icon'] : $options['error_icon'];
         $view->vars['tab_active'] = false;
-        
+
         $view->parent->vars['tabbed'] = true;
     }
 

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -86,7 +86,7 @@
 {% spaceless %}
 <ul class="{{ form.vars.attr.class }}">
     {% for tab in form.vars.tabs %}
-        <li{% if loop.first %} class="active"{% endif %}>
+        <li{% if tab.active %} class="active"{% endif %}>
             <a data-toggle="tab" href="#{{ tab.id }}">
                 {% if tab.icon %}<i class="icon-{{ tab.icon }}"></i>{% endif %}
                 {{ tab.label }}
@@ -487,7 +487,7 @@
         {% set data_prototype = 'collection' in form.vars.block_prefixes and not omit_collection_item ? '<div class="collection-item ' ~ widget_items_attr.class|default()|join(' ') ~ '" id="' ~ prototype.vars.id ~ '_control_group">' ~ form_row(prototype) ~ '</div>' : form_row(prototype) %}
         {% set data_prototype_name = form.vars.form.vars.prototype.vars.name|default('__name__') %}
         {% set widget_form_group_attr = widget_form_group_attr|merge({'data-prototype': data_prototype, 'data-prototype-name': data_prototype_name})|merge(attr) %}
-    {% endif %}    
+    {% endif %}
     {% set widget_form_group_attr = widget_form_group_attr|merge({'id': id ~ '_control_group', 'class': widget_form_group_attr.class|default('') ~ ' ' ~ row_wrapper_class}) %}
     {% if errors|length > 0 %}
         {% set widget_form_group_attr = widget_form_group_attr|merge({'class': widget_form_group_attr.class|default('') ~ ' error'}) %}


### PR DESCRIPTION
If you have an error in one of your tabs it will become the active tab when the form is rendered again. Also, the icon in the form will change to an error icon. *Need to setup a global configuration option for tab error icons. 

@peshi - Let me know what you think
