### PR TITLE
Introduce postInstallMirrorTwitterBootstrap scripts

### DIFF
--- a/Command/BaseBootstrapSymlinkCommand.php
+++ b/Command/BaseBootstrapSymlinkCommand.php
@@ -44,7 +44,7 @@ abstract class BaseBootstrapSymlinkCommand extends ContainerAwareCommand
             $cmanager = new ComposerPathFinder($composer);
             $options = array(
                     'targetSuffix' => DIRECTORY_SEPARATOR . "Resources" . DIRECTORY_SEPARATOR . static::$targetSuffix,
-                    'sourcePrefix' => '..' . DIRECTORY_SEPARATOR
+                    'sourcePrefix' => '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR
                 );
             list($symlinkTarget, $symlinkName) = $cmanager->getSymlinkFromComposer(
                 self::$mopaBootstrapBundleName,
@@ -67,9 +67,7 @@ abstract class BaseBootstrapSymlinkCommand extends ContainerAwareCommand
                 $this->output->writeln(" ... <comment>not existing</comment>");
                 $this->output->writeln("Mirroring from: " . $symlinkName);
                 $this->output->write("for Target: " . $symlinkTarget);
-
-                $filesystem = new Filesystem();
-                $filesystem->mirror($symlinkTarget, $symlinkName, null, array('copy_on_windows' => true, 'delete' => true, 'override' => true));
+                self::createMirror($symlinkTarget, $symlinkName);
             }
         } else {
             $this->output->write("Checking Symlink");
@@ -202,5 +200,25 @@ EOF
         if (false === $target = readlink($symlinkName)) {
             throw new \Exception("Symlink $symlinkName points to target $target");
         }
+    }
+
+    /**
+     * Create the mirror
+     *
+     * @param string $symlinkTarget The Target
+     * @param string $symlinkName   The Name
+     *
+     * @throws \Exception
+     */
+    public static function createMirror($symlinkTarget, $symlinkName)
+    {
+        $filesystem = new Filesystem();
+        $filesystem->mkdir($symlinkName);
+        $filesystem->mirror(
+            realpath($symlinkName . DIRECTORY_SEPARATOR . $symlinkTarget),
+            $symlinkName,
+            null,
+            array('copy_on_windows' => true, 'delete' => true, 'override' => true)
+        );
     }
 }

--- a/Composer/ScriptHandler.php
+++ b/Composer/ScriptHandler.php
@@ -37,6 +37,29 @@ class ScriptHandler
         $IO->write(" ... <info>OK</info>");
     }
 
+    public static function postInstallMirrorTwitterBootstrap(Event $event)
+    {
+        $IO = $event->getIO();
+        $composer = $event->getComposer();
+        $cmanager = new ComposerPathFinder($composer);
+        $options = array(
+            'targetSuffix' => DIRECTORY_SEPARATOR . "Resources" . DIRECTORY_SEPARATOR . "bootstrap",
+            'sourcePrefix' => '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR
+        );
+        list($symlinkTarget, $symlinkName) = $cmanager->getSymlinkFromComposer(
+            BootstrapSymlinkLessCommand::$mopaBootstrapBundleName,
+            BootstrapSymlinkLessCommand::$twitterBootstrapName,
+            $options
+        );
+
+        $IO->write("Checking Mirror", FALSE);
+        if (false === BootstrapSymlinkLessCommand::checkSymlink($symlinkTarget, $symlinkName)) {
+            $IO->write("Creating Mirror: " . $symlinkName, FALSE);
+            BootstrapSymlinkLessCommand::createMirror($symlinkTarget, $symlinkName);
+        }
+        $IO->write(" ... <info>OK</info>");
+    }
+
     public static function postInstallSymlinkTwitterBootstrapSass(Event $event)
     {
         $IO = $event->getIO();
@@ -56,6 +79,29 @@ class ScriptHandler
         if (false === BootstrapSymlinkSassCommand::checkSymlink($symlinkTarget, $symlinkName, true)) {
             $IO->write(" ... Creating Symlink: " . $symlinkName, FALSE);
             BootstrapSymlinkSassCommand::createSymlink($symlinkTarget, $symlinkName);
+        }
+        $IO->write(" ... <info>OK</info>");
+    }
+
+    public static function postInstallMirrorTwitterBootstrapSass(Event $event)
+    {
+        $IO = $event->getIO();
+        $composer = $event->getComposer();
+        $cmanager = new ComposerPathFinder($composer);
+        $options = array(
+            'targetSuffix' => DIRECTORY_SEPARATOR . "Resources" . DIRECTORY_SEPARATOR . "bootstrap-sass",
+            'sourcePrefix' => '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR
+        );
+        list($symlinkTarget, $symlinkName) = $cmanager->getSymlinkFromComposer(
+            BootstrapSymlinkSassCommand::$mopaBootstrapBundleName,
+            BootstrapSymlinkSassCommand::$twitterBootstrapName,
+            $options
+        );
+
+        $IO->write("Checking Mirror", FALSE);
+        if (false === BootstrapSymlinkSassCommand::checkSymlink($symlinkTarget, $symlinkName)) {
+            $IO->write(" ... Creating Mirror: " . $symlinkName, FALSE);
+            BootstrapSymlinkSassCommand::createMirror($symlinkTarget, $symlinkName);
         }
         $IO->write(" ... <info>OK</info>");
     }


### PR DESCRIPTION
The "mopa:bootstrap:symlink:less" console command has a "--no-symlink" option, which can be used to make mirrors instead of symlinks.
But nothing has been made for the composer postInstall scripts. With this PR, you can now use 
"Mopa\Bundle\BootstrapBundle\Composer\ScriptHandler::postInstallMirrorTwitterBootstrap"
instead of 
"Mopa\Bundle\BootstrapBundle\Composer\ScriptHandler::postInstallSyminkTwitterBootstrap"
in "post-install-cmd" && "post-update-cmd"

I also think all this part should be refactored to avoidcode duplication between "Command" and "Composer" classes.
Why not a "ScriptHandler::InstallBootstrap" && "console mopa:install:bootstrap" with sass/less related options and default to mirror instead of symlink (like symfony does)
