### PR TITLE
Update 2.3 version for composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want to use bootstrap 2:
 
 {
     "require": {
-        "mopa/bootstrap-bundle": "2.3.x-dev",
+        "mopa/bootstrap-bundle": "2.3.*@dev",
         "twbs/bootstrap": "v2.3.2"
     }
 }


### PR DESCRIPTION
I'm not sure if there has been a recent change in packagist, but i couldn't install the bundle for 2.3 with the composer example in the readme
