### PR TITLE
Split widget_addon to widget_addon_prepend and widget_addon_append.

### DIFF
--- a/Form/Extension/WidgetFormTypeExtension.php
+++ b/Form/Extension/WidgetFormTypeExtension.php
@@ -5,7 +5,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\Exception\CreationException;
+use Symfony\Component\Form\Exception\InvalidConfigurationException;
 
 class WidgetFormTypeExtension extends AbstractTypeExtension
 {
@@ -18,26 +18,26 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
 
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if (!is_array($options['widget_addon'])) {
-            throw new CreationException("The 'widget_addon' option must be an array");
+        if (null !== $options['widget_addon_prepend'] && !is_array($options['widget_addon_prepend'])) {
+            throw new InvalidConfigurationException("The 'widget_addon_prepend' option must be an array");
+        }
+        if (null !== $options['widget_addon_append'] && !is_array($options['widget_addon_append'])) {
+            throw new InvalidConfigurationException("The 'widget_addon_append' option must be an array");
         }
         if (in_array('percent', $view->vars['block_prefixes'])) {
-            if ($options['widget_addon']['type'] === null) {
-                $options['widget_addon']['type'] = 'append';
+            if ($options['widget_addon_append'] === null) {
+                $options['widget_addon_append'] = array();
             }
         }
         if (in_array('money', $view->vars['block_prefixes'])) {
-            if ($options['widget_addon']['type'] === null) {
-                $options['widget_addon']['type'] = 'prepend';
+            if ($options['widget_addon_prepend'] === null) {
+                $options['widget_addon_prepend'] = array();
             }
-        }
-        if (((isset($options['widget_addon']['text']) && $options['widget_addon']['text'] !== null)
-                || (isset($options['widget_addon']['icon']) && $options['widget_addon']['icon'] !== null)) && $options['widget_addon']['type'] === null) {
-            throw new \Exception('You must provide a "type" for widget_addon');
         }
 
         $view->vars['widget_form_group'] = $options['widget_form_group'];
-        $view->vars['widget_addon'] = $options['widget_addon'];
+        $view->vars['widget_addon_prepend'] = $options['widget_addon_prepend'];
+        $view->vars['widget_addon_append'] = $options['widget_addon_append'];
         $view->vars['widget_prefix'] = $options['widget_prefix'];
         $view->vars['widget_suffix'] = $options['widget_suffix'];
         $view->vars['widget_type'] = $options['widget_type'];
@@ -51,11 +51,8 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
         $resolver->setDefaults(
             array(
                 'widget_form_group' => true,
-                'widget_addon' => array(
-                    'type' => null, //false: dont add anything, null: using presets, anything; prepend; append
-                    'icon' => null,
-                    'text' => null,
-                ),
+                'widget_addon_prepend' => null,
+                'widget_addon_append' => null,
                 'widget_prefix' => null,
                 'widget_suffix' => null,
                 'widget_type' => '',

--- a/Resources/doc/3-form-extension-templates.md
+++ b/Resources/doc/3-form-extension-templates.md
@@ -55,7 +55,7 @@ Form Legends
 
 Every Form component representing a Form, not a Field, (e.g. subforms, widgets of type date beeing expanded, etc)
 has now a attribute called show_legend which controls wether the "form legend" is shown or not.
-      
+
 This can be controlled globally by adapting your config.yml:
 
 ``` yaml
@@ -63,7 +63,7 @@ mopa_bootstrap:
     form:
         show_legend: false # default is true
 ```
-      
+
 Now you can tell a specific form to have the legend beeing shown by using:
 
 ``` php
@@ -72,13 +72,13 @@ public function buildForm(FormBuilder $builder, array $options)
     $builder->setAttribute('show_legend', true);
     // ...
 ```
-    
-    
+
+
 Child Form Legends
 ------------------
 
-In symfony2 you can easily glue different forms together and build a nice tree. 
-Normally there is a label for every sub form (including special widgets like date expanded, radio button expanded, etc) 
+In symfony2 you can easily glue different forms together and build a nice tree.
+Normally there is a label for every sub form (including special widgets like date expanded, radio button expanded, etc)
 with the name of the Subform rendered.
 This might make sense or not. I decided to disable this by default, but enabling it is easy:
 
@@ -90,7 +90,7 @@ mopa_bootstrap:
         show_legend: false # default is true
 ```
 
-If you just want to have it in a special form do it like that: 
+If you just want to have it in a special form do it like that:
 
 ``` php
 // e.g. a form only consisting of subforms
@@ -99,7 +99,7 @@ public function buildForm(FormBuilder $builder, array $options)
     $builder->setAttribute('show_legend', false); // no legend for main form
     $child = $builder->create('user', new SomeSubFormType(), array('show_child_legend' => true)); // but legend for this subform
     $builder->add($child);
-    // ... 
+    // ...
 ```
 
 Field Labels
@@ -109,7 +109,7 @@ You have the option to remove a specific field label by setting label_render to 
 
 ``` php
        $builder
-            ->add('somefield', null, array( 
+            ->add('somefield', null, array(
                 'label_render' => false
             ))
 ```
@@ -121,7 +121,7 @@ Form Field Help
 
 Every Form Field component representing a Field, not a Form, (e.g. inputs, textarea, radiobuttons beeing not expanded etc)
 has several new attributes:
-     
+
   - help_inline: beeing shown right of the element if there is space
   - help_block:  beeing shown under the element
   - help_label:  beeing shown under the label of the element
@@ -145,12 +145,30 @@ public function buildForm(FormBuilder $builder, array $options)
         ))
     ;
     //...
-``` 
+```
 
 Widget Addons
 -------------
+You can integrate Twitter Bootstrap's form addons, you have the choice between `icon` or `text` options:
 
-To get the addons working, i had to increase max nesting level of xdebug to 200.
+```php
+public function buildForm(FormBuilder $builder, array $options)
+{
+    $builder
+        ->add('price', null, array(
+            "widget_addon_append" => array(
+                "icon"     => "home",
+            ),
+            "widget_addon_prepend" => array(
+                "text"     => "My text",
+            )
+        ))
+    ;
+    //...
+```
+
+Note: To get the addons working, i had to increase max nesting level of xdebug to 200.
+
 
 ### Form Field Prefix / Suffix
 
@@ -169,7 +187,7 @@ public function buildForm(FormBuilder $builder, array $options)
         ))
     ;
     //...
-``` 
+```
 
 
 Form Errors
@@ -181,7 +199,7 @@ Generally you may want to define your errors to be displayed inline OR block (se
 mopa_bootstrap:
     form:
         error_type: block # or inline which is default
-        
+
 ```
 
 Or on a special Form:
@@ -194,7 +212,7 @@ public function buildForm(FormBuilder $builder, array $options)
             ->setAttribute('error_type', "inline")
     ;
     //...
-``` 
+```
 
 Or on a special field:
 
@@ -206,7 +224,7 @@ public function buildForm(FormBuilder $builder, array $options)
            ->add('country', null, array('error_type'=>'block'))
     ;
     //...
-``` 
+```
 
 In some special cases you may also want to not have a form error but an field error
 so you can use error delay, which will delay the error to the first next field rendered in a child form:
@@ -228,12 +246,12 @@ Widget Attrs
 ------------
 
 // Thanks to JohanLopes and PR #105:
-There are a bunch of other form extenstions, so you can explicitly set the classes of the control tags, 
+There are a bunch of other form extenstions, so you can explicitly set the classes of the control tags,
 by default there is only the control-group and the error (if the widget has error) classes rendered into it :
 
 ``` php
        $builder
-            ->add('somefield', null, array( 
+            ->add('somefield', null, array(
                 'widget_control_group_attr' => array('class'=>'mycontrolgroupclass'),
                 'widget_controls_attr' => array('class'=>'mycontrolsclass'),
                 'label_attr' => array('class'=>'mylabelclass') // this is new in sf2.1 form component
@@ -241,12 +259,12 @@ by default there is only the control-group and the error (if the widget has erro
 ```
 
 will result in
- 
+
 ``` html
 <div id="myWidgetName_control_group" class="mycontrolgroupclass control-group">
     <label class="mylabelclass required control-label">My Label</label>
     <div class="mycontrolsclass controls">
-    
+
     ...
 ```
 

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -32,10 +32,11 @@
 {% block form_widget_simple %}
 {% spaceless %}
     {% set type = type|default('text') %}
-    {% if type != 'hidden' and widget_addon.type|default(null) is not null %}
+    {% if type != 'hidden' and ( widget_addon_prepend|default(null) is not null or widget_addon_append|default(null) is not null ) %}
     <div class="input-group">
-        {% if widget_addon.type == 'prepend' %}
-        {{ block('widget_addon') }}
+        {% if widget_addon_prepend|default(null) is not null %}
+            {% set widget_addon = widget_addon_prepend %}
+            {{ block('widget_addon') }}
         {% endif %}
     {% endif %}
     {% if not widget_remove_btn|default(null) %}
@@ -43,8 +44,9 @@
     {% endif %}
     {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
     <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
-    {% if type != 'hidden' and  widget_addon.type|default(null) is not null %}
-        {% if widget_addon.type == 'append' %}
+    {% if type != 'hidden' and ( widget_addon_prepend|default(null) is not null or widget_addon_append|default(null) is not null ) %}
+        {% if widget_addon_append|default(null) is not null %}
+        {% set widget_addon = widget_addon_append %}
         {{ block('widget_addon') }}
         {% endif %}
     </div>
@@ -235,14 +237,14 @@
 
 {% block percent_widget %}
 {% spaceless %}
-    {% set widget_addon = widget_addon|merge({'text': widget_addon.text|default('%')}) %}
+    {% set widget_addon_append = widget_addon_append|merge({'text': widget_addon_append.text|default('%')}) %}
     {{ block('form_widget_simple') }}
 {% endspaceless %}
 {% endblock percent_widget %}
 
 {% block money_widget %}
 {% spaceless %}
-    {% set widget_addon = widget_addon|merge({'text': money_pattern|replace({ '{{ widget }}': ''})}) %}
+    {% set widget_addon_prepend = widget_addon_prepend == null and money_pattern != '{{ widget }}' ? {'text': money_pattern|replace({ '{{ widget }}': ''})} : widget_addon_prepend|default(null) %}
     {{ block('form_widget_simple') }}
 {% endspaceless %}
 {% endblock money_widget %}
@@ -415,7 +417,8 @@
 {% spaceless %}
 {# prevent deep nesting wrong context copy error #}
 {% from 'MopaBootstrapBundle::icons.html.twig' import icon %}
-<span class="input-group-addon">{{ (widget_addon.text|default(false) ? widget_addon.text|trans({}, translation_domain) : icon(widget_addon.icon))|raw  }}</span>
+{% set widget_addon_icon = widget_addon.icon is defined ? widget_addon.icon : null  %}
+    <span class="input-group-addon">{{ (widget_addon.text|default(false) ? widget_addon.text|trans({}, translation_domain) : icon(widget_addon_icon))|raw }}</span>
 {% endspaceless %}
 {% endblock widget_addon %}
 


### PR DESCRIPTION
 Patch converted from PR #534.

Split widget_addon to widget_addon_prepend and widget_addon_append.

Additionally, fixed issue with money widget implementation where it was overwriting settings instead of defaulting them and also did not work with the currency: false setting.
