### PR TITLE
navbar extension can be disabled

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -169,6 +169,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->arrayNode('navbar')
+                    ->canBeDisabled()
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('template')

--- a/DependencyInjection/MopaBootstrapExtension.php
+++ b/DependencyInjection/MopaBootstrapExtension.php
@@ -52,7 +52,7 @@ class MopaBootstrapExtension extends Extension
                 }
             }
         }
-        if (isset($config['navbar'])) {
+        if (isset($config['navbar']) && $config['navbar']['enabled']) {
             $yamlloader->load("navbar_extension.yml");
             foreach ($config['navbar'] as $key => $value) {
                 $container->setParameter(

--- a/Resources/doc/4-navbar-generation.md
+++ b/Resources/doc/4-navbar-generation.md
@@ -20,6 +20,17 @@ mopa_bootstrap:
     navbar: ~
 ```
 
+## Disable the extension
+
+To completely disable the navbar extensions (i.e. you don't want to use it at all) just add the
+following in your config.yml
+
+``` yaml
+mopa_bootstrap:
+    navbar:
+        enabled: false
+```
+
 ## Special Menu Options
 
 We register a new menu extension so you have options available to you:


### PR DESCRIPTION
The navbar extension cannot be disabled because the `addDefaultsIfNotSet()` config call sets the default values.
This PR fixes this issue, the navbar can be disabled in the config.yml like this:

```
mopa_bootstrap:
    navbar:
        enabled: false
```

It's fully backward compatible, and enabled by default.
