### PR TITLE
Added configuration reference

### DIFF
--- a/Resources/doc/configuration-reference.md
+++ b/Resources/doc/configuration-reference.md
@@ -1,0 +1,62 @@
+Mopa Bootstrap Configuration Reference
+=========================================
+
+Default configuration for extension with alias: "mopa_bootstrap"
+
+```yaml
+mopa_bootstrap:
+    version:                            ~
+    form:
+        templating:                     MopaBootstrapBundle:Form:fields.html.twig
+        horizontal_label_class:         col-lg-3
+        horizontal_input_wrapper_class: col-lg-9
+        render_fieldset:                true
+        render_collection_item:         true
+        show_legend:                    true
+        show_child_legend:              false
+        checkbox_label:                 both
+        render_optional_text:           true
+        render_required_asterisk:       false
+        error_type:                     ~
+        tooltip:
+            icon:                       icon-info-sign
+            placement:                  top
+        tabs:
+            class:                      nav nav-tabs
+        popover:
+            icon:                       icon-info-sign
+            placement:                  top
+        collection:
+            widget_remove_btn:
+                attr:
+                    class:              btn
+                icon:                   ~
+                icon_color:             ~
+            widget_add_btn:
+                attr:
+                    class:              btn
+                icon:                   ~
+                icon_color:             ~
+    navbar:
+        enabled:                        false
+    initializr:
+        meta:
+            title:                      MopaBootstrapBundle
+            description:                MopaBootstrapBundle
+            keywords:                   MopaBootstrapBundle, Twitter Bootstrap, HTML5 Boilerplate
+            author_name:                My name
+            author_url:                 #
+            feed_atom:                  ~
+            feed_rss:                   ~
+            sitemap:                    ~
+            nofollow:                   false
+            noindex:                    false
+        dns_prefetch:
+
+            # Default:
+            - //ajax.googleapis.com
+        google:
+            wt:                   ~
+            analytics:            ~
+        diagnostic_mode:          false
+```

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -15,6 +15,7 @@ MopaBootstrapBundle provides several features to assist you quickly building app
 
 Additional doc:
 
+- [Configuration Reference](configuration-reference.md)
 - [Including bootstrap](including-bootstrap.md)
 - [Css vs less](css-vs-less.md)
 - [Using Sass as preprocessor](sass-configuration.md)


### PR DESCRIPTION
Add a configuration reference for all options. Probably could use some comments but at least it's here now. Just need to make sure people re-dump or update this when there are changes to the config. Is `version` being used anymore?
