### PR TITLE
fix "The function "mopa_bootstrap_navbar" does not exist"

### DIFF
--- a/DependencyInjection/MopaBootstrapExtension.php
+++ b/DependencyInjection/MopaBootstrapExtension.php
@@ -34,6 +34,7 @@ class MopaBootstrapExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('twig.xml');
         $loader->load('form.xml');
+        $loader->load('navbar.xml');
 
         if (isset($config['form'])) {
             foreach ($config['form'] as $key => $value) {
@@ -52,8 +53,8 @@ class MopaBootstrapExtension extends Extension
                 }
             }
         }
+        
         if (isset($config['navbar']) && $config['navbar']['enabled']) {
-            $loader->load('navbar.xml');
             foreach ($config['navbar'] as $key => $value) {
                 $container->setParameter(
                     'mopa_bootstrap.navbar.'.$key,


### PR DESCRIPTION
Always load navbar twig extension since Twig always requires it.
So no new config parameters are required on basic installation
