### PR TITLE
Add missing colon in configuration example

### DIFF
--- a/Resources/doc/50-initializr.md
+++ b/Resources/doc/50-initializr.md
@@ -9,7 +9,7 @@ To make fast start there is only 2 step process to use it.
 
 ```yaml
 # app/config/config.yml
-mopa_bootstrap
+mopa_bootstrap:
     initializr: ~
 ```
 


### PR DESCRIPTION
This simply fixes a typo in the docs.
