### PR TITLE
Stack subnav pills

### DIFF
--- a/Navbar/Factory/NavbarExtension.php
+++ b/Navbar/Factory/NavbarExtension.php
@@ -17,6 +17,10 @@ class NavbarExtension implements ExtensionInterface
             $item->setChildrenAttribute('class', 'nav nav-pills');
         }
 
+        if($options['subnavbar-stacked']) {
+            $item->setChildrenAttribute('class', 'nav nav-pills nav-stacked');
+        }
+
         if ($options['dropdown_header']) {
             $item
                 ->setAttribute('role', 'presentation')
@@ -61,6 +65,7 @@ class NavbarExtension implements ExtensionInterface
         return array_merge(array(
             'navbar' => false,
             'subnavbar' => false,
+            'subnavbar-stacked' => false,
             'dropdown_header' => false,
             'dropdown' => false,
             'caret' => false,


### PR DESCRIPTION
Add new configuration option, to allow to stack pills in subnavbar vertically, as commented in bootstrap 3 doc.
