### PR TITLE
Add a twig function called icon instead of using imports / macros.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('mopa_bootstrap');
         $this->addFormConfig($rootNode);
+        $this->addIconsConfig($rootNode);
         $this->addNavbarConfig($rootNode);
         $this->addInitializrConfig($rootNode);
 
@@ -217,6 +218,32 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                  ->end()
                             ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    protected function addIconsConfig(ArrayNodeDefinition $rootNode)
+    {
+        $iconSets = array('glyphicons', 'fontawesome');
+
+        $rootNode
+            ->children()
+                ->arrayNode('icons')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('icon_set')
+                            ->info('Icon set to use')
+                            ->defaultValue('glyphicons')
+                            ->validate()
+                                ->ifNotInArray($iconSets)
+                                ->thenInvalid('Must choose one of '.json_encode($iconSets))
+                            ->end()
+                        ->end()
+                        ->scalarNode('shortcut')
+                            ->info('Alias for mopa_bootstrap_icon()')
+                            ->defaultValue('icon')
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/MopaBootstrapExtension.php
+++ b/DependencyInjection/MopaBootstrapExtension.php
@@ -35,7 +35,7 @@ class MopaBootstrapExtension extends Extension
         $loader->load('twig.xml');
         $loader->load('bootstrap.xml');
         if(isset($config['bootstrap'])){
-            if(isset($config['bootstrap']['install_path'])){                
+            if(isset($config['bootstrap']['install_path'])){
                 $container->setParameter(
                         'mopa_bootstrap.bootstrap.install_path',
                         $config['bootstrap']['install_path']
@@ -49,12 +49,7 @@ class MopaBootstrapExtension extends Extension
             $loader->load('form.xml');
             foreach ($config['form'] as $key => $value) {
                 if (is_array($value)) {
-                    foreach ($config['form'][$key] as $subkey => $subvalue) {
-                        $container->setParameter(
-                                'mopa_bootstrap.form.'.$key.'.'.$subkey,
-                                $subvalue
-                        );
-                    }
+                    $this->remapParameters($container, 'mopa_bootstrap.form.'.$key, $config['form'][$key]);
                 } else {
                     $container->setParameter(
                         'mopa_bootstrap.form.'.$key,
@@ -63,29 +58,35 @@ class MopaBootstrapExtension extends Extension
                 }
             }
         }
-        
+
+        /**
+         * Navbar
+         */
         if ($this->isConfigEnabled($container, $config['navbar'])) {
             $loader->load('navbar.xml');
-            foreach ($config['navbar'] as $key => $value) {
-                $container->setParameter(
-                    'mopa_bootstrap.navbar.'.$key,
-                    $value
-                );
-            }
+            $this->remapParameters($container, 'mopa_bootstrap.navbar', $config['navbar']);
         }
 
-        // set container parameters for Initializr base template
-        if (isset($config['initializr'])) {
-            // load Twig extension mapping config variables to Twig Globals
-            $loader->load('initializr.xml');
-            
-            $container->setParameter('mopa_bootstrap.initializr.meta',$config['initializr']['meta']);
-            $container->setParameter('mopa_bootstrap.initializr.google',$config['initializr']['google']);
-            $container->setParameter('mopa_bootstrap.initializr.dns_prefetch',$config['initializr']['dns_prefetch']);
+        /**
+         * Icons
+         */
+        if (isset($config['icons'])) {
+            $this->remapParameters($container, 'mopa_bootstrap.icons', $config['icons']);
+        }
 
-            // TODO: think about setting this default as kernel debug,
-            // what about PROD env which does not need diagnostic mode and test
-            $container->setParameter('mopa_bootstrap.initializr.diagnostic_mode', $config['initializr']['diagnostic_mode']);
+        /**
+         * Initializr
+         */
+        if (isset($config['initializr'])) {
+            $loader->load('initializr.xml');
+            $this->remapParameters($container, 'mopa_bootstrap.initializr', $config['initializr']);
+        }
+    }
+
+    private function remapParameters(ContainerBuilder $container, $prefix, $config)
+    {
+        foreach ($config as $key => $value) {
+            $container->setParameter(sprintf('%s.%s', $prefix, $key), $value);
         }
     }
 }

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -6,11 +6,17 @@
 
     <parameters>
         <parameter key="mopa_bootstrap.twig.extension.bootstrap_form.class">Mopa\Bundle\BootstrapBundle\Twig\MopaBootstrapTwigExtension</parameter>
+        <parameter key="mopa_bootstrap.twig.extension.bootstrap_icon.class">Mopa\Bundle\BootstrapBundle\Twig\MopaBootstrapIconExtension</parameter>
     </parameters>
 
     <services>
         <service id="mopa_bootstrap.twig.extension.bootstrap_form" class="%mopa_bootstrap.twig.extension.bootstrap_form.class%">
-            <argument type="service" id="service_container" />
+            <tag name="twig.extension" />
+        </service>
+
+        <service id="mopa_bootstrap.twig.extension.bootstrap_icon" class="%mopa_bootstrap.twig.extension.bootstrap_icon.class%">
+            <argument>%mopa_bootstrap.icons.icon_set%</argument>
+            <argument>%mopa_bootstrap.icons.shortcut%</argument>
             <tag name="twig.extension" />
         </service>
     </services>

--- a/Resources/doc/configuration-reference.md
+++ b/Resources/doc/configuration-reference.md
@@ -5,55 +5,77 @@ Default configuration for extension with alias: "mopa_bootstrap"
 
 ```yaml
 mopa_bootstrap:
-    bootstrap:
-        install_path:                   Resources/public/bootstrap
     form:
-        templating:                     MopaBootstrapBundle:Form:fields.html.twig
-        horizontal_label_class:         col-lg-3
-        horizontal_input_wrapper_class: col-lg-9
-        render_fieldset:                true
-        render_collection_item:         true
-        show_legend:                    true
-        show_child_legend:              false
-        checkbox_label:                 both
-        render_optional_text:           true
-        render_required_asterisk:       false
-        error_type:                     ~
-        tooltip:
-            icon:                       icon-info-sign
-            placement:                  top
+        templating:           MopaBootstrapBundle:Form:fields.html.twig
+        horizontal_label_class:  col-lg-3 control-label
+        horizontal_label_offset_class:  col-lg-offset-3
+        horizontal_input_wrapper_class:  col-lg-9
+        render_fieldset:      true
+        render_collection_item:  true
+        show_legend:          true
+        show_child_legend:    false
+        checkbox_label:       both
+        render_optional_text:  true
+        render_required_asterisk:  false
+        error_type:           ~
         tabs:
-            class:                      nav nav-tabs
-        popover:
-            icon:                       icon-info-sign
-            placement:                  top
+            class:                nav nav-tabs
+        help_widget:
+            popover:
+                title:                ~
+                content:              ~
+                trigger:              hover
+                toggle:               popover
+                placement:            right
+        help_label:
+            tooltip:
+                title:                ~
+                text:                 ~
+                icon:                 info-sign
+                placement:            top
+            popover:
+                title:                ~
+                content:              ~
+                text:                 ~
+                icon:                 info-sign
+                placement:            top
         collection:
             widget_remove_btn:
                 attr:
-                    class:              btn
-                icon:                   ~
-                icon_color:             ~
+                    class:                btn btn-default
+                label:                remove_item
+                icon:                 ~
+                icon_color:           ~
             widget_add_btn:
                 attr:
-                    class:              btn
-                icon:                   ~
-                icon_color:             ~
+                    class:                btn btn-default
+                label:                add_item
+                icon:                 ~
+                icon_color:           ~
+    icons:
+
+        # Icon set to use
+        icon_set:             glyphicons
+
+        # Alias for mopa_bootstrap_icon()
+        shortcut:             icon
     navbar:
-        enabled:                        false
+        enabled:              false
+
         # Menu template to use when rendering
-        template:                       MopaBootstrapBundle:Menu:menu.html.twig
+        template:             MopaBootstrapBundle:Menu:menu.html.twig
     initializr:
         meta:
-            title:                      MopaBootstrapBundle
-            description:                MopaBootstrapBundle
-            keywords:                   MopaBootstrapBundle, Twitter Bootstrap, HTML5 Boilerplate
-            author_name:                My name
-            author_url:                 #
-            feed_atom:                  ~
-            feed_rss:                   ~
-            sitemap:                    ~
-            nofollow:                   false
-            noindex:                    false
+            title:                MopaBootstrapBundle
+            description:          MopaBootstrapBundle
+            keywords:             MopaBootstrapBundle, Twitter Bootstrap, HTML5 Boilerplate
+            author_name:          My name
+            author_url:           #
+            feed_atom:            ~
+            feed_rss:             ~
+            sitemap:              ~
+            nofollow:             false
+            noindex:              false
         dns_prefetch:
 
             # Default:
@@ -61,5 +83,5 @@ mopa_bootstrap:
         google:
             wt:                   ~
             analytics:            ~
-        diagnostic_mode:          false
+        diagnostic_mode:      false
 ```

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -354,7 +354,7 @@
         <a href="#" data-toggle="tooltip" data-placement="{{ help_label_tooltip.placement}}" data-title="{{ help_label_tooltip.title|trans({}, translation_domain) }}">
             {% if help_label_tooltip.icon is not sameas(false) %}
             <span class="glyphicon glyphicon-{{help_label_tooltip.icon}}"></span>
-            {% endif %}            
+            {% endif %}
             {% if help_label_tooltip.text is not sameas(null) %}
             {{ help_label_tooltip.text }}
             {% endif %}
@@ -367,7 +367,7 @@
         <a href="#" data-toggle="popover" data-trigger="hover" data-placement="{{ help_label_popover.placement}}" data-title="{{ help_label_popover.title|trans({}, translation_domain) }}" data-content="{{ help_label_popover.content|trans({}, translation_domain) }}" >
             {% if help_label_popover.icon is not sameas(false) %}
             <span class="glyphicon glyphicon-{{help_label_popover.icon}}"></span>
-            {% endif %}            
+            {% endif %}
             {% if help_label_popover.text is not sameas(null) %}
             {{ help_label_popover.text }}
             {% endif %}
@@ -467,10 +467,8 @@
 
 {% block widget_addon %}
 {% spaceless %}
-{# prevent deep nesting wrong context copy error #}
-{% from 'MopaBootstrapBundle::icons.html.twig' import icon %}
 {% set widget_addon_icon = widget_addon.icon is defined ? widget_addon.icon : null  %}
-    <span class="input-group-addon">{{ (widget_addon.text|default(false) ? widget_addon.text|trans({}, translation_domain) : icon(widget_addon_icon))|raw }}</span>
+    <span class="input-group-addon">{{ (widget_addon.text|default(false) ? widget_addon.text|trans({}, translation_domain) : mopa_bootstrap_icon(widget_addon_icon)) }}</span>
 {% endspaceless %}
 {% endblock widget_addon %}
 

--- a/Resources/views/Menu/menu.html.twig
+++ b/Resources/views/Menu/menu.html.twig
@@ -3,15 +3,14 @@
 {% block linkElement %}
 {% spaceless %}
 {% import 'knp_menu.html.twig' as macros %}
-{% from 'MopaBootstrapBundle::icons.html.twig' import icon %}
 <a href="{{ item.uri }}"{{ macros.attributes(item.linkAttributes) }}>
 {% if item.extras.icon|default(false) %}
-    {{ icon(item.extras.icon, item.extras.icon_white|default(false)) }}
-{% endif %}
-    <span>{{ block('label') }}</span>
-{% if item.extras.caret|default(false) %}
+    {{ mopa_bootstrap_icon(item.extras.icon, item.extras.icon_white|default(false)) }}{{ ' ' }}
+{%- endif %}
+{{ block('label') }}
+{%- if item.extras.caret|default(false) %}
     <b class="caret"></b>
-{% endif %}
+{% endif -%}
 </a>
 {% endspaceless %}
 {% endblock %}

--- a/Resources/views/icons.html.twig
+++ b/Resources/views/icons.html.twig
@@ -1,3 +1,11 @@
 {% macro icon(name, inverted) %}
 <span class="glyphicon glyphicon-{{ name }}"{% if inverted|default(false) %} style="color: white;"{% endif %}></span>
 {% endmacro %}
+
+{% block fontawesome -%}
+<i class="icon-{{ icon }}{{ inverted ? ' inverted' : '' }}"></i>
+{%- endblock %}
+
+{% block glyphicons -%}
+<span class="glyphicon glyphicon-{{ icon }}"{% if inverted|default(false) %} style="color: white;"{% endif %}></span>
+{%- endblock %}

--- a/Twig/MopaBootstrapIconExtension.php
+++ b/Twig/MopaBootstrapIconExtension.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Mopa\Bundle\BootstrapBundle\Twig;
+
+/**
+ * Mopa Bootstrap Icon Extension
+ *
+ * @author Craig Blanchette (isometriks) <craig.blanchette@gmail.com>
+ */
+class MopaBootstrapIconExtension extends \Twig_Extension
+{
+    /**
+     * @var \Twig_Environment
+     */
+    protected $environment;
+    protected $iconSet;
+    protected $shortcut;
+    protected $iconTemplate;
+
+    public function __construct($iconSet, $shortcut = null)
+    {
+        $this->iconSet = $iconSet;
+        $this->shortcut = $shortcut;
+    }
+
+    /**
+     * @param \Twig_Environment $environment
+     */
+    public function initRuntime(\Twig_Environment $environment)
+    {
+        $this->environment = $environment;
+    }
+
+    public function getFunctions()
+    {
+        $functions = array(
+            new \Twig_SimpleFunction('mopa_bootstrap_icon', array($this, 'renderIcon'), array('is_safe' => array('html'))),
+        );
+
+        if ($this->shortcut) {
+            $functions[] = new \Twig_SimpleFunction($this->shortcut, array($this, 'renderIcon'), array('is_safe' => array('html')));
+        }
+
+        return $functions;
+    }
+
+    public function renderIcon($icon, $inverted = false)
+    {
+        $template = $this->getIconTemplate();
+        $context = array(
+            'icon' => $icon,
+            'inverted' => $inverted,
+        );
+
+        return $template->renderBlock($this->iconSet, $context);
+    }
+
+    /**
+     * @return \Twig_TemplateInterface $template
+     */
+    protected function getIconTemplate()
+    {
+        if ($this->iconTemplate === null) {
+            $this->iconTemplate = $this->environment->loadTemplate('@MopaBootstrap/icons.html.twig');
+        }
+
+        return $this->iconTemplate;
+    }
+
+    public function getName()
+    {
+        return 'mopa_bootstrap_icon';
+    }
+}

--- a/Twig/MopaBootstrapTwigExtension.php
+++ b/Twig/MopaBootstrapTwigExtension.php
@@ -9,8 +9,6 @@
 
 namespace Mopa\Bundle\BootstrapBundle\Twig;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
 /**
  * Add new twig functions related to forms
  *
@@ -19,27 +17,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class MopaBootstrapTwigExtension extends \Twig_Extension
 {
-    protected $container;
-
-    protected $environment;
-
-    /**
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-     */
-    public function __construct(ContainerInterface $container)
-    {
-        $this->container = $container;
-    }
-
-    /**
-     *
-     * @param \Twig_Environment $environment
-     */
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->environment = $environment;
-    }
     /**
      * Returns a list of functions to add to the existing list.
      *


### PR DESCRIPTION
@phiamo, don't merge this yet. 

This was just to illustrate one of the ideas I had about solving this. It works pretty well, in configuration you'd just do:

```
mopa_bootstrap:
    icons:
        icon_set: fontawesome  # defaults to glyphicons so no BC here
```

This will allow us to add more icon styles and using a template instead of just a prefix will allow other fonts that may have data attributes or something. 

One issue I can think of is name collisions. Maybe instead we should rename the icon function to `mopa_bootstrap_icon`? It's kind of long but would fit with the other function namings like the navbar.. It would be nice to have it be configurable, so it would default to `icon` but you could change it if it caused problems, and have an alias  `mopa_bootstrap_icon` to use in the templates from the bundle. Not sure. 

Also note that I removed the `<span>` from the menu.html.twig and there should now only be a space after an icon. Otherwise there will be no space and it should be inline anyway.
