### PR TITLE
Issue: initial_size always 0

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -105,7 +105,7 @@
         	  options.collection_id = this.id.length === 0 ? '' : '#' + this.id;
           }
           if (!data){
-              options.initial_size = $this.find('.collection-items').children().length;
+              options.initial_size = $this.parent().next('.collection-items').children().length;
               $this.data('collection', (data = new Collection(this, options)));
           }
           if (option == 'add') {


### PR DESCRIPTION
```
options.initial_size = $this.find('.collection-items').children().length;
```

Would always be set to 0 since it couldn't find the '.collection_items' element , fixed with :

```
options.initial_size = $this.parent().next('.collection-items').children().length;
```
