### PR TITLE
Fixed issue with prototype label not being correctly replaced in sub-forms

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -61,14 +61,22 @@
         addPrototype: function(index) {
             var $collection = $(this.options.collection_id);
             var prototype_name = $collection.attr('data-prototype-name');
+            var prototype_label = $collection.attr('data-prototype-label');
 
             // Just in case it doesnt get it
             if(typeof prototype_name === 'undefined'){
                 prototype_name = '__name__';
             }
-            var replace_pattern = new RegExp(prototype_name, 'g');
 
-            var rowContent = $collection.attr('data-prototype').replace(replace_pattern, index);
+            if(typeof prototype_label === 'undefined'){
+                prototype_name = '__name__label__';
+            }
+            var name_replace_pattern = new RegExp(prototype_name, 'g');
+            var label_replace_pattern = new RegExp(prototype_label, 'g');
+
+            var rowContent = $collection.attr('data-prototype')
+                .replace(label_replace_pattern, index)
+                .replace(name_replace_pattern, index);
             var row = $(rowContent);
             
             $collection.children('.collection-items').append(row);

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -560,7 +560,12 @@
     {% endif %}
     {% if prototype is defined %}
         {% set data_prototype_name = form.vars.form.vars.prototype.vars.name|default('__name__') %}
-        {% set widget_form_group_attr = widget_form_group_attr|merge({'data-prototype': prototype_markup, 'data-prototype-name': data_prototype_name})|merge(attr) %}
+        {% set data_prototype_label = form.vars.form.vars.prototype.vars.label|default('__name__label__') %}
+        {% set widget_form_group_attr = widget_form_group_attr|merge({
+            'data-prototype': prototype_markup,
+            'data-prototype-name': data_prototype_name,
+            'data-prototype-label': data_prototype_label
+        })|merge(attr) %}
     {% endif %}
     {# collection item adds class to form-group #}
     {% set widget_form_group_attr = widget_form_group_attr|merge({'class': widget_form_group_attr.class ~ ' ' ~ id ~ '_form_group'}) %}


### PR DESCRIPTION
If you use a collection of custom form types, the label in the prototype is `__name__label__`.
This PR fixes this issue, by replacing the label with the current index.
