### PR TITLE
Take care of safe_label options for pure HTML rendering

### DIFF
--- a/Resources/views/Menu/menu.html.twig
+++ b/Resources/views/Menu/menu.html.twig
@@ -15,4 +15,5 @@
 {% endspaceless %}
 {% endblock %}
 
-{% block label %}{{ item.label|trans()}}{% endblock %}
+{% block label %}{% if options.allow_safe_labels and item.getExtra('safe_label', false) %}{{ item.label|trans()|raw }}{% else %}{{ item.label|trans() }}{% endif %}{% endblock %}
+


### PR DESCRIPTION
Just cleaning that hack, as it breaks the safe label functionnality from Knp Menu
Linked to workaround for issue #629
