### PR TITLE
Removing the datepicker in base_initializr.html.twig

### DIFF
--- a/Resources/views/base_initializr.html.twig
+++ b/Resources/views/base_initializr.html.twig
@@ -179,7 +179,6 @@
         '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-subnav.js'
         '@MopaBootstrapBundle/Resources/public/js/html5bp_plugins.js'
         '@MopaBootstrapBundle/Resources/public/js/html5bp_script.js'
-        '@MopaBootstrapBundle/Resources/public/js/eyecon-bootstrap-datepicker.js'
         output='js/foot_compiled.js'
     %}
     <script type="text/javascript" src="{{ asset_url }}"></script>


### PR DESCRIPTION
That file doesn't exist so it causes a compilation exception
