### PR TITLE
Ensure all error messages have .text-error

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -411,6 +411,7 @@
 {% else %}
     {% if errors|length > 0 %}
     <span class="help-{{ block('error_type') }}">
+        <span class="text-error">
             {% for error in errors %}
                 {{
                     error.messagePluralization is null
@@ -418,6 +419,7 @@
                         : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators')
                 }} <br>
             {% endfor %}
+        </span>
     </span>
     {% endif %}
 {% endif %}


### PR DESCRIPTION
This fix ensures that all error messages are displayed with the error colour.

At the moment any errors that bubble to the top of the form are displayed in black text. The reason I have put a second span inside the span is because help-block was not red when on the same span.

References #463
