### PR TITLE
Adding missing use statement

### DIFF
--- a/Twig/MenuExtension.php
+++ b/Twig/MenuExtension.php
@@ -4,6 +4,7 @@ namespace Mopa\Bundle\BootstrapBundle\Twig;
 
 use Mopa\Bundle\BootstrapBundle\Menu\Converter\MenuConverter;
 use Knp\Menu\Twig\Helper;
+use Knp\Menu\ItemInterface;
 
 /**
  * Extension for rendering a bootstrap menu


### PR DESCRIPTION
if-block in L#59 couldn't work because ItemInterface was not imported.

```
if (!$menu instanceof ItemInterface) {
```
