### PR TITLE
Rename twbs to twitter

### DIFF
--- a/Command/BaseBootstrapSymlinkCommand.php
+++ b/Command/BaseBootstrapSymlinkCommand.php
@@ -39,7 +39,7 @@ abstract class BaseBootstrapSymlinkCommand extends ContainerAwareCommand
     /**
      * Get Package involved
      *
-     * @return string Name of twbs package
+     * @return string Name of twitter package
      */
     abstract protected function getTwitterBootstrapName();
 

--- a/Command/BootstrapSymlinkLessCommand.php
+++ b/Command/BootstrapSymlinkLessCommand.php
@@ -8,7 +8,7 @@ namespace Mopa\Bundle\BootstrapBundle\Command;
 class BootstrapSymlinkLessCommand extends BaseBootstrapSymlinkCommand
 {
     public static $mopaBootstrapBundleName = "mopa/bootstrap-bundle";
-    public static $twitterBootstrapName = "twbs/bootstrap";
+    public static $twitterBootstrapName = "twitter/bootstrap";
 
     protected function getTwitterBootstrapName()
     {
@@ -24,7 +24,7 @@ class BootstrapSymlinkLessCommand extends BaseBootstrapSymlinkCommand
             ->setHelp(<<<EOT
 The <info>mopa:bootstrap:symlink:less</info> command helps you checking and symlinking/mirroring the twitters/bootstrap library.
 
-By default, the command uses composer to retrieve the paths of MopaBootstrapBundle and twbs/bootstrap in your vendors.
+By default, the command uses composer to retrieve the paths of MopaBootstrapBundle and twitter/bootstrap in your vendors.
 
 If you want to control the paths yourself specify the paths manually:
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ NOTICE:
 
 Recent BC breaks:
 
- * dc4fd12: [BC Break] Removed inline completely 
+ * dc4fd12: [BC Break] Removed inline completely
  * add75e9: Renamed config mopa_bootstrap.navbar to mopa_bootstrap.menu
 
 
 BS3 (master branch of this bundle) is nearly stable see [Beta-3](https://github.com/phiamo/MopaBootstrapBundle/releases/tag/v3.0.0-beta3)
 BS2 (v2.3.x) is quite stable
 
-BC breaking changes will probably not be ported to 2.3. 
+BC breaking changes will probably not be ported to 2.3.
 
 
 Branches
@@ -33,7 +33,7 @@ To use this bundle with boostrap 3 use the master branch:
 {
     "require": {
         "mopa/bootstrap-bundle": "v3.0.0-beta2",
-        "twbs/bootstrap": "v3.0.0"
+        "twitter/bootstrap": "v3.0.0"
     }
 }
 ```
@@ -46,12 +46,12 @@ If you want to use bootstrap 2:
 {
     "require": {
         "mopa/bootstrap-bundle": "2.3.x-dev",
-        "twbs/bootstrap": "v2.3.2"
+        "twitter/bootstrap": "v2.3.2"
     }
 }
 ```
 To understand which versions are currently required have a look into `BRANCHES.md`
- 
+
 Documentation
 -------------
 
@@ -62,7 +62,7 @@ In any case, if something is not working as expected after a update:
 
 Recent BackwardsCompatibility breaking changes:
 
-* c892cd9: Changed the way how navbars are created, read the [doc](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/4-navbar-generation.md) 
+* c892cd9: Changed the way how navbars are created, read the [doc](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/4-navbar-generation.md)
 * a4b78d5: Added Version Detection for BS2 or BS3
 * 5f1200f: Changed the widget_addon form parameter to use type (prepend/append) instead of append (true/false)
 
@@ -88,7 +88,7 @@ Installation instructions are located in the
 Included Features
 -----------------
 
-* Bootstrap Version detection via Composer Brigde 
+* Bootstrap Version detection via Composer Brigde
 * Twig Extensions and templates for use with symfony2 Form component
   * control your form either via the form builder or the template engine
   * control nearly every bootstrap2 form feature
@@ -108,10 +108,10 @@ We need to add more info here
 
 <h4>Bootstrap 3</h4>
 
-We now officially suport bootstrap3 in our master branch, 
+We now officially suport bootstrap3 in our master branch,
 The default is to determine Version by composer, this means, MopaBootstrapBundle tries to determine
 which version you have installed, and configures itself to use it. This is done in a compiler pass and stored in local cache.
-If for any reason this does not wor for you, you might want to set the 
+If for any reason this does not wor for you, you might want to set the
 
 We have several files seperated for bs2 and bs3 to be abled to support both e.g. forms:
  * https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/views/Form/fields_bs_2.html.twig

--- a/Resources/doc/1-installation.md
+++ b/Resources/doc/1-installation.md
@@ -29,7 +29,7 @@ Installation
 1. Add this bundle to your project in composer.json:
 
     1.1. Plain BootstrapBundle
-    
+
     ```json
     {
         "require": {
@@ -46,7 +46,7 @@ Installation
     {
         "require": {
             "mopa/bootstrap-bundle": "dev-master",
-            "twbs/bootstrap": "dev-master"
+            "twitter/bootstrap": "dev-master"
         }
     }
     ```
@@ -57,7 +57,7 @@ Installation
     {
         "require": {
             "mopa/bootstrap-bundle": "dev-master",
-            "twbs/bootstrap": "dev-master",
+            "twitter/bootstrap": "dev-master",
             "knplabs/knp-paginator-bundle": "dev-master",
             "knplabs/knp-menu-bundle": "dev-master",
             "knplabs/knp-menu": "2.0.*@dev",
@@ -116,15 +116,15 @@ Installation
     php app/console mopa:bootstrap:symlink:sass
     ```
 
-    With these steps taken, bootstrap should be install into vendor/twbs/bootstrap/ and a symlink
+    With these steps taken, bootstrap should be install into vendor/twitter/bootstrap/ and a symlink
     been created into vendor/mopa/bootstrap-bundle/Mopa/Bundle/BootstrapBundle/Resources/public/bootstrap.
 
 
     1.5. Include bootstrap manually or in another way:
 
     For including bootstrap there are different solutions, why using this one?
-    have a look into [Including Bootstrap](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/including-bootstrap.md)	
-    
+    have a look into [Including Bootstrap](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/including-bootstrap.md)
+
     1.6 Sass Installation
 
     If you want to use Sass, check out the Documentation on Sass. Basically you just need to add one package to composer.json:
@@ -133,7 +133,7 @@ Installation
        {
            "require": {
                "mopa/bootstrap-bundle": "dev-master",
-               "twbs/bootstrap": "dev-master",
+               "twitter/bootstrap": "dev-master",
                "knplabs/knp-paginator-bundle": "dev-master",
                "knplabs/knp-menu-bundle": "dev-master",
                "craue/formflow-bundle": "dev-master",
@@ -199,7 +199,7 @@ Installation
         form: ~  # Adds twig form theme  support
         menu: ~  # enables twig helpers for menu
     ```
-    
+
 4. If you like further tweak your config.yml (not mandatory)
 
     ``` yaml

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "mopa/composer-bridge": "~1.3"
     },
     "suggest":  {
-        "twbs/bootstrap": ">2.0,<4.0-dev",
+        "twitter/bootstrap": ">2.0,<4.0-dev",
         "knplabs/knp-paginator-bundle": "~2.3",
         "knplabs/knp-menu-bundle": "~2.0@dev",
         "mopa/bootstrap-sandbox-bundle": "~2.3",


### PR DESCRIPTION
`twbs` should be renamed to `twitter`
As `twitter/bootstrap` is the official name on packagist.org

Some spaces have been vanished in this PR, (not done on purpose, but it brings some cleanup whatever)
