### PR TITLE
Not making dropdowns of items affected by depth limit

### DIFF
--- a/Menu/Converter/MenuConverter.php
+++ b/Menu/Converter/MenuConverter.php
@@ -130,7 +130,10 @@ class MenuConverter
     protected function getChildOptions(ItemInterface $item, array $options)
     {
         $childOptions = array();
-        if (in_array($options['automenu'], array('navbar')) && $item->hasChildren()) {
+        
+        $hasChildren = $item->hasChildren() && (!isset($options['depth']) || $options['depth'] > $item->getLevel());
+        
+        if (in_array($options['automenu'], array('navbar')) && $hasChildren) {
             $childOptions = array(
                 'dropdown' => !isset($options['dropdown']) || $options['dropdown'],
                 'caret' => !isset($options['caret']) || $options['caret'],


### PR DESCRIPTION
If the depth is set to 1 for a multi-level menu, the built dropdown ends up unusable as it lacks any children (as expected) and it's uri is set to `#`.

```
{{ mopa_bootstrap_menu('foo', { depth: 1 }) }}
```

This PR introduces a check for the depth option in addition to the existing check of `$item->hasChildren()`.
