### PR TITLE
fixed missing import for InvalidArgumentException

### DIFF
--- a/Form/Extension/HelpFormTypeExtension.php
+++ b/Form/Extension/HelpFormTypeExtension.php
@@ -16,6 +16,7 @@ use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
 
 /**
  * Extension for Help Forms handling


### PR DESCRIPTION
Found this one when trying to play around with some of the field options. 

The missing import causes a `ClassNotFoundException` when you use bad values for some of the options. 
In my case: setting a string value for `help_widget_popover`, which should be an array
