### PR TITLE
Ability to offset (align) a button.

### DIFF
--- a/Form/Extension/OffsetButtonExtension.php
+++ b/Form/Extension/OffsetButtonExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the MopaBootstrapBundle.
+ *
+ * (c) Philipp A. Mohrenweiser <phiamo@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
+
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+/**
+ * Extension for Offsetting a button
+ *
+ * @author peshi <peshis@gmail.com>
+ */
+class OffsetButtonExtension extends AbstractTypeExtension
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return 'button';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(
+            array(
+                'button_offset' => null,
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['button_offset'] = $options['button_offset'];
+
+    }
+}

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -5,6 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
+        <parameter key="mopa_bootstrap.form.type_extension.offsetButton.class">Mopa\Bundle\BootstrapBundle\Form\Extension\OffsetButtonExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.button.class">Mopa\Bundle\BootstrapBundle\Form\Extension\IconButtonExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.help.class">Mopa\Bundle\BootstrapBundle\Form\Extension\HelpFormTypeExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.legend.class">Mopa\Bundle\BootstrapBundle\Form\Extension\LegendFormTypeExtension</parameter>
@@ -20,6 +21,10 @@
     </parameters>
 
     <services>
+        <service id="mopa_bootstrap.form.type_extension.offsetButton" class="%mopa_bootstrap.form.type_extension.offsetButton.class%">
+            <tag name="form.type_extension" alias="button" />
+        </service>
+
         <service id="mopa_bootstrap.form.type_extension.button" class="%mopa_bootstrap.form.type_extension.button.class%">
             <tag name="form.type_extension" alias="button" />
         </service>

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -19,6 +19,23 @@
 {% endspaceless %}
 {% endblock button_widget %}
 
+{% block button_row %}
+    {% spaceless %}
+        {% if button_offset is not empty %}
+            {% set attr = attr|merge({'for': id, 'class': button_offset }) %}
+            <div class="form-group">
+                <div {% for attrname, attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
+                {{ form_widget(form) }}
+                </div>
+            </div>
+        {% else %}
+            <div>
+                {{ form_widget(form) }}
+            </div>
+        {% endif %}
+    {% endspaceless %}
+{% endblock button_row %}
+
 {# Widgets #}
 
 {% block choice_widget_collapsed %}


### PR DESCRIPTION
Example usage:

```
        $builder->add('submit', 'button', array(
                'attr' => array('class' => 'btn-danger'),
                'button_offset' => 'col-lg-offset-3 col-lg-9'
            ));
```
