### PR TITLE
Show "add" button for collections only if required

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -377,7 +377,7 @@
         <label{% for attrname,attrvalue in label_attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
         {{ label|trans({}, translation_domain) }}
         {{- block('label_asterisk') }}
-        {% if 'collection' in form.vars.block_prefixes and widget_add_btn|default(null) %}
+        {% if 'collection' in form.vars.block_prefixes and widget_add_btn|default(null) and form.vars.allow_add == true %}
             {{ block('form_widget_add_btn') }}
         {% endif %}
         {% if help_label %}


### PR DESCRIPTION
Show "add" button for collections only if "allow_add" is not false.
