### PR TITLE
Changed @icon-font-path to relative path

### DIFF
--- a/Resources/public/less/mopabootstrapbundle.less
+++ b/Resources/public/less/mopabootstrapbundle.less
@@ -22,7 +22,7 @@
 @import "../bootstrap/less/bootstrap.less";
 
 // variables
-@icon-font-path: "/bundles/mopabootstrap/bootstrap/fonts/";
+@icon-font-path: "../bootstrap/fonts/";
 
 // The Paginator less for MopaBootstrapBundle
 @import "paginator.less";


### PR DESCRIPTION
Changed @icon-font-path to a relative path so that cssrewrite will work. This should fix broken icons because of a broken absolute url.
