### PR TITLE
Form Actions Support

### DIFF
--- a/Form/Type/FormActionsType.php
+++ b/Form/Type/FormActionsType.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Mopa\Bundle\BootstrapBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\ButtonBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * Class FormActionsType
+ *
+ * Adds support for form actions, printing buttons in a single line, and correctly offset.
+ *
+ * @package Braincrafted\Bundle\BootstrapBundle\Form\Type
+ */
+class FormActionsType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $buttons = array();
+        foreach ($options['buttons'] as $name => $config) {
+            $buttons[] = $this->createButton($builder, $name, $config)->getForm();
+        }
+
+        $builder->setAttribute('buttons', $buttons);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param FormView $view
+     * @param FormInterface $form
+     * @param array $options
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        if (! $form->getConfig()->hasAttribute('buttons')) {
+            return;
+        }
+
+        $view->vars['buttons'] = array_map(
+            function ($button) use ($view) {
+                return $button->createView($view);
+            },
+            $form->getConfig()->getAttribute('buttons')
+        );
+    }
+
+    /**
+     * Adds a button
+     *
+     * @param FormBuilderInterface $builder
+     * @param $name
+     * @param $config
+     * @throws \InvalidArgumentException
+     * @return ButtonBuilder
+     */
+    protected function createButton($builder, $name, $config)
+    {
+        $options = (isset($config['options']))? $config['options'] : array();
+        $button = $builder->create($name, $config['type'], $options);
+
+        if (! $button instanceof ButtonBuilder) {
+            throw new \InvalidArgumentException(
+                "The FormActionsType only accepts buttons, got type '{$config['type']}' for field '$name'"
+            );
+        }
+
+        return $button;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+                'buttons'        => array(),
+                'options'        => array(),
+                'mapped'         => false,
+            ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'form_actions';
+    }
+}

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -19,6 +19,7 @@
         <parameter key="mopa_bootstrap.form.type_extension.time.class">Mopa\Bundle\BootstrapBundle\Form\Extension\TimeTypeExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.tabbed.class">Mopa\Bundle\BootstrapBundle\Form\Extension\TabbedFormTypeExtension</parameter>
         <parameter key="mopa_bootstrap.form.type.tab.class">Mopa\Bundle\BootstrapBundle\Form\Type\TabType</parameter>
+        <parameter key="mopa_bootstrap.form.type.form_actions.class">Mopa\Bundle\BootstrapBundle\Form\Type\FormActionsType</parameter>
     </parameters>
 
     <services>
@@ -117,6 +118,10 @@
 
         <service id="mopa_bootstrap.form.type.tab" class="%mopa_bootstrap.form.type.tab.class%">
             <tag name="form.type" alias="tab" />
+        </service>
+
+        <service id="mopa_bootstrap.form.type.form_actions" class="%mopa_bootstrap.form.type.form_actions.class%">
+            <tag name="form.type" alias="form_actions" />
         </service>
     </services>
 </container>

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -425,9 +425,16 @@
     </span>
 {% endblock help_label_popover %}
 
-
+{% block form_actions_widget %}
+    {% for button in buttons %}
+        {{ form_widget(button) }}&nbsp; {# this needs to be here due to https://github.com/twbs/bootstrap/issues/3245 #}
+    {% endfor  %}
+{% endblock %}
 
 {# Rows #}
+{% block form_actions_row %}
+    {{ block('button_row')  }}
+{% endblock %}
 
 {% block form_rows_visible %}
 {% spaceless %}


### PR DESCRIPTION
This allows you to add buttons in a collection that prints them all together.

The syntax used on the form objects is:

```
  ->add('buttons', 'form_actions', [
      'buttons' => [
          'save' => ['type' => 'submit', 'options' => ['label' => 'button.save']],
          'cancel' => ['type' => 'button', 'options' => ['label' => 'button.cancel']],
      ]
  ]);
```

The offset button extension may need some adjustments to work here.

_Caveat:_
Bootstrap relies on the presence of whitespace between buttons to show them with proper spacing. Since most of the form stuff in symfony is encapsulated by `spaceless` at one point or another, the only way to ensure space between buttons is by using a `&nbsp;`. Which i did in the template.
Another possible solution is to add a custom style that adds the margin, but this breaks the "don't touch bootstrap" way of things and adds custom CSS, probably not a good idea.
