### PR TITLE
Fix button_offset for form_actions

### DIFF
--- a/Form/Extension/OffsetButtonExtension.php
+++ b/Form/Extension/OffsetButtonExtension.php
@@ -23,7 +23,6 @@ use Symfony\Component\Form\FormView;
  */
 class OffsetButtonExtension extends AbstractTypeExtension
 {
-
     /**
      * {@inheritdoc}
      */
@@ -37,11 +36,9 @@ class OffsetButtonExtension extends AbstractTypeExtension
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults(
-            array(
-                'button_offset' => null,
-            )
-        );
+        $resolver->setDefaults(array(
+            'button_offset' => null,
+        ));
     }
 
     /**
@@ -50,6 +47,5 @@ class OffsetButtonExtension extends AbstractTypeExtension
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['button_offset'] = $options['button_offset'];
-
     }
 }

--- a/Form/Type/FormActionsType.php
+++ b/Form/Type/FormActionsType.php
@@ -5,6 +5,8 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ButtonBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -50,7 +52,16 @@ class FormActionsType extends AbstractType
             'buttons' => array(),
             'options' => array(),
             'mapped' => false,
+            'button_offset' => null,
         ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['button_offset'] = $options['button_offset'];
     }
 
     /**


### PR DESCRIPTION
Fixes button offset for the form actions. I didn't want to change the other extension to 'form' and give extra bogus options to irrelevant form types.
