### PR TITLE
Fix form horizontal inheritance and add "form-horizontal" to the root fo...

### DIFF
--- a/Form/Extension/HorizontalFormTypeExtension.php
+++ b/Form/Extension/HorizontalFormTypeExtension.php
@@ -43,10 +43,40 @@ class HorizontalFormTypeExtension extends AbstractTypeExtension
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['horizontal'] = $options['horizontal'];
+        // Set the root form to the default value if none given
+        if (!$view->parent && $options['compound'] && $options['horizontal'] === null) {
+            $horizontal = $this->options['horizontal'];
+        } else {
+            $horizontal = $options['horizontal'];
+        }
+
+        $view->vars['horizontal'] = $horizontal;
         $view->vars['horizontal_label_class'] = $options['horizontal_label_class'];
         $view->vars['horizontal_label_offset_class'] = $options['horizontal_label_offset_class'];
         $view->vars['horizontal_input_wrapper_class'] = $options['horizontal_input_wrapper_class'];
+    }
+
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        if (!$view->parent && $options['compound'] && $view->vars['horizontal']) {
+            $class = isset($view->vars['attr']['class']) ? $view->vars['attr']['class'] . ' ' : '';
+            $view->vars['attr']['class'] = $class . 'form-horizontal';
+
+            $this->setChildrenHorizontal($view);
+        }
+    }
+
+    public function setChildrenHorizontal(FormView $view)
+    {
+        foreach ($view->children as $child) {
+            if ($child->vars['horizontal'] === null) {
+                $child->vars['horizontal'] = $view->vars['horizontal'];
+            }
+
+            if (count($view->children) > 0){
+                $this->setChildrenHorizontal($child);
+            }
+        }
     }
 
     /**
@@ -56,7 +86,7 @@ class HorizontalFormTypeExtension extends AbstractTypeExtension
     {
         $resolver->setDefaults(
             array(
-                'horizontal' => $this->options['horizontal'],
+                'horizontal' => null,
                 'horizontal_label_class' => $this->options['horizontal_label_class'],
                 'horizontal_label_offset_class' => $this->options['horizontal_label_offset_class'],
                 'horizontal_input_wrapper_class' => $this->options['horizontal_input_wrapper_class'],


### PR DESCRIPTION
https://github.com/phiamo/MopaBootstrapBundle/issues/813
https://github.com/phiamo/MopaBootstrapBundle/issues/801
https://github.com/phiamo/MopaBootstrapBundle/issues/775

This will make it so the `horizontal` view variable is inherited from the element's parent. So if you want to non-horizontal a whole form you can do that, or if you want a specific sub-section to all be non-horizontal you can do that too. 

This also adds form-horizontal to the form itself so you can now use `form_start` / `form` and not have to use setDefaultOptions to add a class name. 
