### PR TITLE
Fix $icon-font-path for allow override.

### DIFF
--- a/Resources/public/sass/mopabootstrapbundle.scss
+++ b/Resources/public/sass/mopabootstrapbundle.scss
@@ -17,7 +17,7 @@
  */
 
 // variables
-$icon-font-path: "/bundles/mopabootstrap/bootstrap/fonts/";
+$icon-font-path: "/bundles/mopabootstrap/bootstrap/fonts/" !default;
 
 // Bootstrap overrides, such as the asset-url(..) function.
 @import "bootstrap_and_overrides";


### PR DESCRIPTION
Appended "!default" in variable $icon-font-path.
