### PR TITLE
Show error in help block in non-horizontal form

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -95,7 +95,7 @@
         {% endif %}
     </div>
     {% endif %}
-    {% if type != 'hidden' and horizontal %}
+    {% if type != 'hidden' %}
         {{ block('form_message') }}
     {% endif %}
 {% endspaceless %}


### PR DESCRIPTION
In bootstrap error messages are shown in both horizontal and non-horizontal form
