### PR TITLE
Allow other attributes and additional classes on tab-panes

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -149,9 +149,10 @@
 {% endblock %}
 
 {% block form_tab %}
-<div class="tab-pane{{ form.vars.tab_active ? ' active' : '' }}" id="{{ id }}">
-    {{ block('form_widget') }}
-</div>
+    {% set tab_attr = attr|merge({'class': 'tab-pane' ~ (form.vars.tab_active ? ' active' : '') ~ ' ' ~ attr.class|default(''), 'id': id}) %}
+    <div{% for attrname, attrvalue in tab_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+        {{ block('form_widget') }}
+    </div>
 {% endblock %}
 
 {% block collection_widget %}


### PR DESCRIPTION
If you add attributes like so:

```
$tab = $builder->create('mytab', 'tab', array(
    'attr' => array(
        'class' => 'something',
        'data-id' => 45,
    ),
));
```

It will show up in tab panes:

```
<div class="tab-pane active something" data-id="45">
```
