### PR TITLE
Merge individual attributes of collection buttons with global attributes [v2.3]

### DIFF
--- a/Form/Extension/WidgetCollectionFormTypeExtension.php
+++ b/Form/Extension/WidgetCollectionFormTypeExtension.php
@@ -24,9 +24,10 @@ class WidgetCollectionFormTypeExtension extends AbstractTypeExtension
             if (isset($options['widget_add_btn']['attr']) && !is_array($options['widget_add_btn']['attr'])) {
                 throw new InvalidConfigurationException('The "widget_add_btn.attr" option must be an "array".');
             }
-            if (!isset($options['widget_add_btn']['attr'])) {
-                $options['widget_add_btn']['attr'] = $this->options['widget_add_btn']['attr'];
-            }
+            $options['widget_add_btn']['attr'] = isset($options['widget_add_btn']['attr'])
+                ? array_replace($this->options['widget_add_btn']['attr'], $options['widget_add_btn']['attr'])
+                : $this->options['widget_add_btn']['attr']
+            ;
             if (!isset($options['widget_add_btn']['label']) && !isset($options['widget_add_btn']['icon'])) {
                 throw new InvalidConfigurationException('Provide either "icon" or "label" to "widget_add_btn"');
             }
@@ -43,9 +44,10 @@ class WidgetCollectionFormTypeExtension extends AbstractTypeExtension
             if (isset($options['widget_remove_btn']) && !is_array($options['widget_remove_btn'])) {
                 throw new InvalidConfigurationException('The "widget_remove_btn" option must be an "array".');
             }
-            if (!isset($options['widget_remove_btn']['attr'])) {
-                $options['widget_remove_btn']['attr'] = $this->options['widget_remove_btn']['attr'];
-            }
+            $options['widget_remove_btn']['attr'] = isset($options['widget_remove_btn']['attr'])
+                ? array_replace($this->options['widget_remove_btn']['attr'], $options['widget_remove_btn']['attr'])
+                : $this->options['widget_remove_btn']['attr']
+            ;
             if (!isset($options['widget_remove_btn']['label']) && !isset($options['widget_remove_btn']['icon'])) {
                  throw new InvalidConfigurationException('Provide either "icon" or "label" to "widget_remove_btn"');
             }


### PR DESCRIPTION
In the current 2.3 branch, we are using in one of our projects, the globally configured attributes of collection buttons are thrown away, if you setting only one attribute in your form type.

For example:

``` yaml
# app/config/config.yml
mopa_bootstrap:
    form:
        collection:
            widget_remove_btn:
                attr: { class: "btn btn-mini btn-danger" }
```

``` php
// Acme\ProductionBundle\Form\VariantType
$builder
    ->add('productionQuantities', 'collection', array(
        // ...
        'options' => array(
            'widget_remove_btn' => [
                'attr' => ['ng-click' => 'onRemoveProductionQuantity()'],
            ],
        ),
    ));
```

This leads to a remove button, that does not have a `class` attribute, but only `ng-click`.

It would be much better to merge the attributes with the global configured attributes. This is done in this PR. It would be nice if this could be merged.

Thanks.
