### PR TITLE
FIX: removed sass version scripts from base.html.twig

### DIFF
--- a/Resources/views/base.html.twig
+++ b/Resources/views/base.html.twig
@@ -112,14 +112,6 @@
     Otherwise the regeneration is done on every load in dev more with use_controller: true
      #}
     {% block foot_script_assetic %}
-        {% javascripts
-        '@MopaBootstrapBundle/Resources/public/bootstrap-sass/vendor/assets/javascripts/bootstrap/tooltip.js'
-        '@MopaBootstrapBundle/Resources/public/bootstrap-sass/vendor/assets/javascripts/bootstrap/*.js'
-        '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-collection.js'
-        '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-subnav.js'
-        %}
-            <script type="text/javascript" src="{{ asset_url }}"></script>
-        {% endjavascripts %}
     {% endblock foot_script_assetic %}
 
     <script type="text/javascript">


### PR DESCRIPTION
This should not be here it crashes less version
