### PR TITLE
Ability to disable add/remove buttons

### DIFF
--- a/Form/Extension/WidgetCollectionFormTypeExtension.php
+++ b/Form/Extension/WidgetCollectionFormTypeExtension.php
@@ -49,7 +49,7 @@ class WidgetCollectionFormTypeExtension extends AbstractTypeExtension
                 throw new InvalidArgumentException('The "widget_add_btn" option must be an "array".');
             }
 
-            if ((isset($options['allow_add']) && true === $options['allow_add']) || $options['widget_add_btn']) {
+            if ((isset($options['allow_add']) && true === $options['allow_add']) && $options['widget_add_btn']) {
                 if (isset($options['widget_add_btn']['attr']) && !is_array($options['widget_add_btn']['attr'])) {
                     throw new InvalidArgumentException('The "widget_add_btn.attr" option must be an "array".');
                 }
@@ -62,7 +62,7 @@ class WidgetCollectionFormTypeExtension extends AbstractTypeExtension
                 throw new InvalidArgumentException('The "widget_remove_btn" option must be an "array".');
             }
 
-            if ((isset($options['allow_delete']) && true === $options['allow_delete']) || $options['widget_remove_btn']) {
+            if ((isset($options['allow_delete']) && true === $options['allow_delete']) && $options['widget_remove_btn']) {
                 if (isset($options['widget_remove_btn']) && !is_array($options['widget_remove_btn'])) {
                     throw new InvalidArgumentException('The "widget_remove_btn" option must be an "array".');
                 }


### PR DESCRIPTION
I had to disable "add" or "remove" buttons, to I tried this configuration:

```
->add('items', 'collection', array(
    'allow_add' => true,
    'widget_add_btn' => null,
));
```

but the button still appeared.

With this modification, add_button and remove_button are disablable
