### PR TITLE
Update base_initializr.html.twig

### DIFF
--- a/Resources/views/base_initializr.html.twig
+++ b/Resources/views/base_initializr.html.twig
@@ -138,11 +138,12 @@
     {% endblock container %}
 
     {% block foot_script %}
-    {# Load jQuery from Google CDN
+    {% block jquery %}
+      {# Load jQuery from Google CDN
        http://encosia.com/3-reasons-why-you-should-let-google-host-jquery-for-you/ #}
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-    <script>window.jQuery || document.write('<script src="../js/libs/jquery-1.11.0.min.js"><\/script>')</script>
-
+      <script src="{% block jquery_cdn_url %}//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js{% endblock jquery_cdn_url %}"></script>
+      <script>window.jQuery || document.write('<script src="{% block jquery_local_url %}../js/libs/jquery-1.11.0.min.js{% endblock jquery_local_url %}"><\/script>')</script>
+    {% endblock jquery %}
     {# Asynchronous Google Analytics snippet grabbed from:
        http://mathiasbynens.be/notes/async-analytics-snippet#dont-push-it #}
     {# more GA tweaks:


### PR DESCRIPTION
I propose this small change to improve even more this wonderful bundle.

My reasons were:
- Needed a specific version of jquery
- Needed to set up a different place for local copy of jquery
- Didn't want to override the whole foot_script block
- Thought that this blocks add more development flexibility
