### PR TITLE
[RFC] Allow different uri values for Dropdown menus

### DIFF
--- a/Navbar/AbstractNavbarMenuBuilder.php
+++ b/Navbar/AbstractNavbarMenuBuilder.php
@@ -75,7 +75,7 @@ abstract class AbstractNavbarMenuBuilder
         if ($push_right) {
             $this->pushRight($rootItem);
         }
-        $dropdown = $rootItem->addChild($title, array_merge($knp_item_options, array('uri'=>'#')))
+        $dropdown = $rootItem->addChild($title, array_merge(array('uri'=>'#'), $knp_item_options))
             ->setLinkattribute('class', 'dropdown-toggle')
             ->setLinkattribute('data-toggle', 'dropdown')
             ->setAttribute('class', 'dropdown')


### PR DESCRIPTION
This allows a dropdown menu in the navbar to have a default hyperlink value other than "#". If you want more info I will explain but basically the dropdown menu doesn't work if the user has javascript disabled, this allows a clickable link if that is the case.
