### PR TITLE
do not render input and print errors

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -486,7 +486,6 @@
 
 {% block form_message %}
 {% spaceless %}
-    {{ form_errors(form) }}
     {{ block('form_help') }}
 {% endspaceless %}
 {% endblock form_message %}


### PR DESCRIPTION
fix for issue #884

to render the input and the error-message in one function/block, makes it hard to customize the output. Renderings like 

```
    {{ form_widget(contact_form.name) }}
    {{ form_label(contact_form.name) }}
    {{ form_errors(contact_form.name) }}
```

are not possible. This breaks the parent behavior from symfony.
