### PR TITLE
Use nbsp in checkbox label if empty

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -216,6 +216,8 @@
     {% if label_render %}
         {% if widget_checkbox_label in ['both', 'widget'] %}
             {{ label|trans({}, translation_domain) }}
+        {% else %}
+            &nbsp;
         {% endif %}
     </label>
     {% endif %}


### PR DESCRIPTION
To keep the label tag from having a 0 height (causing the checkbox to be mispositioned), some text needs to be in the label. This uses a nonbreaking space when checkbox_label is set to 'label'. See #898.
