### PR TITLE
Fixed the custom LESS and SASS for collection-item

### DIFF
--- a/Resources/public/less/collections.less
+++ b/Resources/public/less/collections.less
@@ -1,8 +1,11 @@
 /*!
  * MopaBootstrapBundle collection support
  */
-.controls {
+.row, .form-group {
     .collection-item {
         margin-bottom: 9px;
+        padding-left: (@grid-gutter-width / 2);
+        padding-right: (@grid-gutter-width / 2);
+        &:extend(.clearfix all);
     }
 }

--- a/Resources/public/sass/collections.scss
+++ b/Resources/public/sass/collections.scss
@@ -1,8 +1,11 @@
 /*!
  * MopaBootstrapBundle collection support
  */
-.controls {
+.row, .form-group {
     .collection-item {
         margin-bottom: 9px;
+        padding-left: ($grid-gutter-width / 2);
+        padding-right: ($grid-gutter-width / 2);
+        @include clearfix();
     }
 }


### PR DESCRIPTION
Collection items content exceeds the parent columns width. The PR fixes this and also the old .controls selector which was removed in bootstrap v3.x.
