### PR TITLE
Added support framework.validation.transaltion_domain parameter

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -558,21 +558,12 @@
         {% if form.parent == null %}
             {% from 'MopaBootstrapBundle::flash.html.twig' import flash %}
             {% for error in errors %}
-                {{
-                    flash('danger', error.messagePluralization is null
-                        ? error.messageTemplate|trans(error.messageParameters, 'validators')
-                        : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators')
-                    )
-                }}
+                {{ flash('danger', error.message) }}
             {% endfor %}
         {% else %}
             <span class="help-{{ block('error_type') }}">
             {% for error in errors %}
-                {{
-                    error.messagePluralization is null
-                        ? error.messageTemplate|trans(error.messageParameters, 'validators')
-                        : error.messageTemplate|transchoice(error.messagePluralization, error.messageParameters, 'validators')
-                }} <br>
+                {{ error.message }} <br>
             {% endfor %}
             </span>
         {% endif %}


### PR DESCRIPTION
Hello!
In symfony more that v2.3 errors violation added with already pluralization:
src v2.3: https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/Validator/ExecutionContext.php#L92
src v2.5: https://github.com/symfony/symfony/blob/2.5/src/Symfony/Component/Validator/ExecutionContext.php#L95
src master: 
This pull request remove hardcoded 'validators' translation domain, to support    framework.validation.transaltion_domain parameter of app/config/config.yml
