### PR TITLE
[Collections] Removed hardcoded div from selector

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -29,7 +29,7 @@
 
         // This must work with "collections" inside "collections", and should
         // select its children, and not the "collection" inside children.
-        var $collection = $('div' + this.options.collection_id);
+        var $collection = $(this.options.collection_id);
 
         // Indexes must be different for every Collection
         if (typeof this.options.index === 'undefined') {


### PR DESCRIPTION
This PR removes the hardcoded div from the collection selector to make it possible to have collections for e.g. tables.

Fixes #781.
