### PR TITLE
remove vendor directory ?

### DIFF
--- a/Resources/views/base_sass.html.twig
+++ b/Resources/views/base_sass.html.twig
@@ -15,8 +15,8 @@
 
 {% block foot_script_assetic %}
     {% javascripts
-    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/vendor/assets/javascripts/bootstrap/tooltip.js'
-    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/vendor/assets/javascripts/bootstrap/*.js'
+    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/assets/javascripts/bootstrap/tooltip.js'
+    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/assets/javascripts/bootstrap/*.js'
     '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-collection.js'
     '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-subnav.js'
     %}


### PR DESCRIPTION
When I installed twbs/bootstrap-sass, assets where not copied to vendor but directly in assets.
I'm not a bootstrap expert but I think vendor has been removed in the latest version.
