### PR TITLE
fixed changed paths for twbs/bootstrap bundle

### DIFF
--- a/Resources/views/base_sass.html.twig
+++ b/Resources/views/base_sass.html.twig
@@ -15,8 +15,8 @@
 
 {% block foot_script_assetic %}
     {% javascripts
-    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/vendor/assets/javascripts/bootstrap/tooltip.js'
-    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/vendor/assets/javascripts/bootstrap/*.js'
+    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/assets/javascripts/bootstrap/tooltip.js'
+    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/assets/javascripts/bootstrap/*.js'
     '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-collection.js'
     '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-subnav.js'
     %}


### PR DESCRIPTION
In the new version of the twbs/bootstrap bundle the vendor folder has been removed. Because of the static reference the template has to be fixed.
