### PR TITLE
keep the same naming style

### DIFF
--- a/Resources/views/base_initializr.html.twig
+++ b/Resources/views/base_initializr.html.twig
@@ -118,9 +118,9 @@
         {% endif %}
     {% endblock head_style %}
 
-    {% block head_scripts %}
+    {% block head_script %}
         <script type="text/javascript" src="{{ asset('bundles/mopabootstrap/js/modernizr-2.7.1-respond-1.4.2.min.js') }}"></script>
-    {% endblock head_scripts %}
+    {% endblock head_script %}
 </head>
 {% endblock head %}
 


### PR DESCRIPTION
and in the `base.html.twig` it's `head_script` too, not `head_scripts`