### PR TITLE
$icon-font-path relative instead of absolute + !default for own adjustments

### DIFF
--- a/Resources/public/sass/mopabootstrapbundle.scss
+++ b/Resources/public/sass/mopabootstrapbundle.scss
@@ -17,7 +17,7 @@
  */
 
 // variables
-$icon-font-path: "/bundles/mopabootstrap/font/";
+$icon-font-path: "../bundles/mopabootstrap/font/" !default;
 
 // Bootstrap overrides, such as the asset-url(..) function.
 @import "bootstrap_and_overrides";


### PR DESCRIPTION
1. absolute path works only if the website is placed on a TLDs root folder.
2. if one decides to move those files, allow him for doing so