### PR TITLE
Fix DOM element removal in order to be compatible with IE8

### DIFF
--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -99,7 +99,7 @@
                 }
 
                 if (false !== $(window).triggerHandler('before-remove.mopa-collection-item', [$collection, row, oldIndex])) {
-                    row.remove();
+                    row.parentNode.removeChild(row);
                     $(window).triggerHandler('remove.mopa-collection-item', [$collection, row, oldIndex]);
                 }
             }


### PR DESCRIPTION
According to javascript documentation it seems that the element.remove() method does not exist.

Other solution would be to use a jQuery object: `$(row).remove()`
