### PR TITLE
Btn-default for form button by default

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -2,7 +2,7 @@
 
 {# Buttons #}
 {% block button_attributes %}
-    {% set attr = attr|merge({class: 'btn ' ~ attr.class | default("")}) %}
+    {% set attr = attr|merge({class: 'btn ' ~ attr.class | default("btn-default")}) %}
     {{ parent() }}
 {% endblock button_attributes %}
 


### PR DESCRIPTION
Regarding the [Bootstrap docs](http://getbootstrap.com/css/#buttons), button with no extra class must have `btn-default` with the `btn` class.
