### PR TITLE
In datetime_widget in 'datetimepicker' mode, display date if it has value

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -285,7 +285,7 @@
         {% if datetimepicker is defined %}
             {% set widget_addon_icon = widget_addon_append.icon is defined ? widget_addon_append.icon : 'th'  %}
             <div data-provider="datetimepicker" class="input-group date" data-date="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd hh:ii">
-                <input class="form-control" type="text" {% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if 'placeholder' in attr|keys %} placeholder="{{ attr['placeholder'] }}"{% endif %} value="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}">
+                {{ block('form_widget_simple') }}
                 <input type="hidden" value="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" {{ block('widget_attributes') }}>
                 <span class="input-group-addon">{{ mopa_bootstrap_icon(widget_addon_icon) }}</span>
             </div>


### PR DESCRIPTION
If I configure a field as:

```
        ->add('createdAt', null, array(
              'required' => 'required',
              'widget' => "single_text",
              'format' => "yyyy-MM-dd HH:mm",
              'datetimepicker' => true
          ));
```

It is allright in creation mode. But in edit the value of my field createdAt was not displayed. This fix is about to show the initial value.
