### PR TITLE
$options not correctly passed down the the menu item builder.

### DIFF
--- a/Twig/MenuExtension.php
+++ b/Twig/MenuExtension.php
@@ -89,7 +89,7 @@ class MenuExtension extends \Twig_Extension
                 $menu = array_shift($path);
             }
 
-            $menu = $this->helper->get($menu, $path);
+            $menu = $this->helper->get($menu, $path, $options);
         }
 
         $menu = $this->helper->get($menu, array(), $options);


### PR DESCRIPTION
@phiamo any reason in particular why the $options variable is not passed in here?

This seems like a bug to me as it prevents the options for the menu item from being passed down properly.
