### PR TITLE
Fix for incorrect replace of prototype placeholders in nested collections

### DIFF
--- a/Resources/doc/3.1-form-collections.md
+++ b/Resources/doc/3.1-form-collections.md
@@ -62,6 +62,43 @@ Some things are currently missing :
  * examples on howto extend the functionality with check functions for adding and removing
  * in depth example on howto use Custom FormTypes easily
 
+Nested collections
+----------------------
+
+MopaBootstrapBundle supports nested collections. You can use them as shown below.
+
+At first you need to create a child Form Type with some collection
+```php
+class MyChildType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('mySubCollection', 'collection', [
+                    'type' => 'text',
+                ])
+        ;
+    }
+}
+```
+
+After it you need to create a parent Form Type which will use your child form type as a type of collection items.
+
+```php
+class MyParentType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('myCollection', 'collection', [
+                    'type' => new MyChildType(),
+                ])
+        ;
+    }
+}
+```
+That's it.
+
 ---
 
 << [Form Extensions](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/3-form-extension-templates.md) | [Form Tabs](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/3.2-form-tabs.md) >>

--- a/Resources/public/js/mopabootstrap-collection.js
+++ b/Resources/public/js/mopabootstrap-collection.js
@@ -69,11 +69,11 @@
                 prototype_label = '__name__label__';
             }
 
-            var name_replace_pattern = new RegExp(prototype_name, 'g');
-            var label_replace_pattern = new RegExp(prototype_label, 'g');
+            var name_replace_pattern = new RegExp("((\"|&quot;|'|&#039;)((?!(\"|&quot;|'|&#039;|__name__)).)+?)(" + prototype_name + ")", 'ig');
+            var label_replace_pattern = new RegExp("((\"|&quot;|'|&#039;)((?!(\"|&quot;|'|&#039;|__name__)).)+?)(" + prototype_label + ")", 'ig');
             var rowContent = $collection.attr('data-prototype')
-                    .replace(label_replace_pattern, index)
-                    .replace(name_replace_pattern, index);
+                    .replace(label_replace_pattern, "$1" + index)
+                    .replace(name_replace_pattern, "$1" + index);
             var row = $(rowContent);
             if (false !== $(window).triggerHandler('before-add.mopa-collection-item', [$collection, row, index])) {
                 $collection.append(row);


### PR DESCRIPTION
Hello I faced to the issue with nested collections. 
I have three form types.
First one. ProductType:

``` php
<?php
/**
 * @Service("opensoft_onp_web.utils.main_menu_editor.product.form.type")
 * @Tag("form.type", attributes = {"alias" = "product"})
 */
class ProductType extends AbstractType
{
    /**
     * @param FormBuilderInterface $builder
     * @param array $options
     */
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('name', 'text')
            ->add('productOptions', 'collection', [
                    'type' => 'product_option',
                    'options' => ['label_render' => false],
                    'allow_add' => true,
                    'allow_delete' => true,
                    'by_reference' => false,
                    'widget_add_btn' => [
                        'icon' => 'plus-sign',
                        'label' => 'Add product option'
                    ],
                    'widget_remove_btn' => [
                        'icon' => 'minus-sign',
                        'label' => 'Remove'
                    ]
                ])
        ;
    }

    /**
     * @param OptionsResolverInterface $resolver
     */
    public function setDefaultOptions(OptionsResolverInterface $resolver)
    {
        $resolver->setDefaults(array(
            'data_class' => 'Opensoft\Onp\Bundle\CoreBundle\Entity\Product',
            'csrf_protection' => false,
        ));
    }

    /**
     * @return string
     */
    public function getName()
    {
        return 'product';
    }
}
```

Second one. ProductOptionType:

``` php
/**
 * @Service("opensoft_onp_web.utils.main_menu_editor.product_option.form.type")
 * @Tag("form.type", attributes = {"alias" = "product_option"})
 */
class ProductOptionType extends AbstractType
{
    /**
     * @param FormBuilderInterface $builder
     * @param array $options
     */
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
                 ->add(
                'productOptionValues',
                'collection',
                [
                    'type' => 'product_option_value',
                    'options' => ['label_render' => false],
                    'allow_add' => true,
                    'allow_delete' => true,
                    'by_reference' => false,
                    'widget_add_btn' => [
                        'icon' => 'plus-sign',
                        'label' => 'Add product option value'
                    ],
                    'widget_remove_btn' => [
                        'icon' => 'minus-sign',
                        'label' => 'Remove'
                    ]
                ]
            );
    }

    /**
     * @param OptionsResolverInterface $resolver
     */
    public function setDefaultOptions(OptionsResolverInterface $resolver)
    {
        $resolver->setDefaults(
            array(
                'data_class' => 'Opensoft\Onp\Bundle\CoreBundle\Entity\ProductOption',
                'csrf_protection' => false,
            )
        );
    }

    /**
     * @return string
     */
    public function getName()
    {
        return 'product_option';
    }
}
```

And the third one. ProductOptionValueType:

``` php
/**
 * Opensoft\Onp\Bundle\WebBundle\Form\Type\ProductOptionValueType
 *
 * @Service("opensoft_onp_web.utils.main_menu_editor.product_option_value.form.type")
 * @Tag("form.type", attributes = {"alias" = "product_option_value"})
 *
 * @author Richard Fullmer <richard.fullmer@opensoftdev.com>
 */
class ProductOptionValueType extends AbstractType
{
    /**
     * @param FormBuilderInterface $builder
     * @param array $options
     */
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add(
                'optionValue',
                'entity',
                [
                    'class' => 'Opensoft\\Onp\\Bundle\\CoreBundle\\Entity\\OptionValue',
                    'property' => 'title',
                    'label_attr' => array('class' => 'col-lg-2'),
                    'attr' => array('class' => 'col-lg-10'),
                ]
            );
    }

    /**
     * @param OptionsResolverInterface $resolver
     */
    public function setDefaultOptions(OptionsResolverInterface $resolver)
    {
        $resolver->setDefaults(
            array(
                'data_class' => 'Opensoft\Onp\Bundle\CoreBundle\Entity\ProductOptionValue',
            )
        );
    }

    /**
     * @return string
     */
    public function getName()
    {
        return 'product_option_value';
    }
}
```

So when i try to add ProductOption and than ProductOptionValue and save it only ProductOption is saved. It happened because function addPrototype replaced placeholders of ProductOption and ProductOptionValue. After my fix it replaces only a first one.
