### PR TITLE
Update mopabootstrapbundle.scss

### DIFF
--- a/Resources/public/sass/mopabootstrapbundle.scss
+++ b/Resources/public/sass/mopabootstrapbundle.scss
@@ -23,7 +23,7 @@ $icon-font-path: "/bundles/mopabootstrap/fonts/bootstrap/";
 @import "bootstrap_and_overrides";
 
 // Main bootstrap.sass entry point
-@import "../bootstrap-sass/assets/stylesheets/bootstrap/bootstrap";
+@import "../bootstrap-sass/assets/stylesheets/bootstrap";
 
 // The Paginator less for MopaBootstrapBundle
 @import "paginator.scss";


### PR DESCRIPTION
There is no sub-directory inside "bootstrap" directory for bootstrap-sass with ` "twbs/bootstrap-sass": "dev-master"`
It makes compilation fail, this fix it for me.