### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,37 +30,23 @@ Branches
 
 To use this bundle with bootstrap 3 use the latest release:
 
-``` json
-{
-    "require": {
-        "mopa/bootstrap-bundle": "v3.0.0-beta4",
-        "twbs/bootstrap": "v3.2.0"
-    }
-}
+```sh
+composer require mopa/bootstrap-bundle twbs/bootstrap
 ```
 
 If you wish to use the current master branch, then use the following:
 
 
-``` json
-{
-    "require": {
-        "mopa/bootstrap-bundle": "dev-master",
-        "twbs/bootstrap": "dev-master"
-    }
-}
+```sh
+composer require mopa/bootstrap-bundle:dev-master twbs/bootstrap:dev-master
 ```
 
 For bootstrap 2 use the v2.3.x branch:
 
-```json
-{
-    "require": {
-        "mopa/bootstrap-bundle": "2.3.x-dev",
-        "twbs/bootstrap": "v2.3.2"
-    }
-}
+```sh
+composer require mopa/bootstrap-bundle:2.3.x-dev twbs/bootstrap:2.3.2
 ```
+
 To understand which versions are currently required have a look into `BRANCHES.md`
  
 Documentation


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.