### PR TITLE
Fixed: Add the less filter in the stylesheet block

### DIFF
--- a/Resources/views/base_less.html.twig
+++ b/Resources/views/base_less.html.twig
@@ -3,6 +3,7 @@
 {% block head_style %}
     {# Override this block to add your own files! #}
     {% stylesheets
+        filter="less"
         '@MopaBootstrapBundle/Resources/public/less/mopabootstrapbundle.less'
     %}
     <link href="{{ asset_url }}" type="text/css" rel="stylesheet" media="screen" />


### PR DESCRIPTION
The filter less is missing in the stylesheet block, and, depending on the configuration, less is therefore silently ignored on the file making the bundle completely broken.

This fixes this problem.