### PR TITLE
fix tooltip.js path for sass

### DIFF
--- a/Resources/public/sass/mopabootstrapbundle.scss
+++ b/Resources/public/sass/mopabootstrapbundle.scss
@@ -23,7 +23,7 @@ $icon-font-path: "/bundles/mopabootstrap/fonts/bootstrap/";
 @import "bootstrap_and_overrides";
 
 // Main bootstrap.sass entry point
-@import "../bootstrap-sass/assets/stylesheets/bootstrap/bootstrap";
+@import "../bootstrap-sass/assets/stylesheets/bootstrap";
 
 // The Paginator less for MopaBootstrapBundle
 @import "paginator.scss";

--- a/Resources/views/base_sass.html.twig
+++ b/Resources/views/base_sass.html.twig
@@ -15,8 +15,8 @@
 
 {% block foot_script_assetic %}
     {% javascripts
-    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/vendor/assets/javascripts/bootstrap/tooltip.js'
-    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/vendor/assets/javascripts/bootstrap/*.js'
+    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/assets/javascripts/bootstrap/tooltip.js'
+    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/assets/javascripts/bootstrap/*.js'
     '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-collection.js'
     '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-subnav.js'
     %}


### PR DESCRIPTION
in current master of bootstrap-sass, there is no "vendor" subdir