### PR TITLE
fixed formflow-steps template

### DIFF
--- a/Resources/views/Form/formflow_stepList.html.twig
+++ b/Resources/views/Form/formflow_stepList.html.twig
@@ -4,7 +4,7 @@
             <li{% if loop.index == flow.getCurrentStep() %} class="active"{% endif %}>
                 {%- if flow.isAllowDynamicStepNavigation() and (loop.index == 1 or flow.isStepDone(loop.index - 1)) -%}
                     <a href="{{ path(app.request.attributes.get('_route'),
-                            app.request.query.all | craue_addDynamicStepNavigationParameter(flow, loop.index)|merge(app.request.attributes.all)) }}">
+                            app.request.query.all | craue_addDynamicStepNavigationParameters(flow, loop.index)|merge(app.request.attributes.all)) }}">
                         {{- stepDescription|trans -}}
                     </a>
                 {%- else -%}


### PR DESCRIPTION
In 
https://github.com/craue/CraueFormFlowBundle/commit/4a70de089f70a0ed4c4c264072c56035e25be18a
the function name was pluralized
