### PR TITLE
Fixed bootstrap sytlesheets path inside mopabootstrapbundle.scss

### DIFF
--- a/Resources/public/sass/mopabootstrapbundle.scss
+++ b/Resources/public/sass/mopabootstrapbundle.scss
@@ -23,7 +23,7 @@ $icon-font-path: "/bundles/mopabootstrap/fonts/bootstrap/";
 @import "bootstrap_and_overrides";
 
 // Main bootstrap.sass entry point
-@import "../bootstrap-sass/assets/stylesheets/bootstrap/bootstrap";
+@import "../bootstrap-sass/assets/stylesheets/bootstrap/";
 
 // The Paginator less for MopaBootstrapBundle
 @import "paginator.scss";


### PR DESCRIPTION
When using sass configuration, this should be the right path, 
locally I have just one bootstrap directory when using SASS (twbs/bootstrap-sass),
please check