### PR TITLE
Do no apply form control class on file input

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -354,7 +354,6 @@
 {% block file_widget %}
 {% spaceless %}
 {% set type = type|default('file') %}
-{% set attr = attr|merge({'class': attr.class|default('') ~ ' ' ~ widget_form_control_class}) %}
     {% if widget_addon_prepend|default(null) is not null %}
         {% set widget_addon = widget_addon_prepend %}
         {{ block('widget_addon') }}


### PR DESCRIPTION
File input should not have a "form-control" class (see http://getbootstrap.com/css/#forms-example). This PR fixes it.