### PR TITLE
fix date_widget wrapper

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -275,9 +275,9 @@
     {% set attr = attr|merge({'class': attr.class|default('inline')}) %}
     	<div class="row">
         {{ date_pattern|replace({
-            '{{ year }}':  form_widget(form.year, {'attr': {'class': attr.widget_class|default('') ~ ''}, 'horizontal_input_wrapper_class': horizontal_input_wrapper_class|default('col-sm-3')}),
-            '{{ month }}': form_widget(form.month, {'attr': {'class': attr.widget_class|default('') ~ ''}, 'horizontal_input_wrapper_class': horizontal_input_wrapper_class|default('col-sm-3')}),
-            '{{ day }}':   form_widget(form.day, {'attr': {'class': attr.widget_class|default('') ~ ''}, 'horizontal_input_wrapper_class': horizontal_input_wrapper_class|default('col-sm-3')}),
+            '{{ year }}':  '<div class="col-sm-4">'~form_widget(form.year, {'attr': {'class': attr.widget_class|default('') ~ ''}})~'</div>',
+            '{{ month }}': '<div class="col-sm-4">'~form_widget(form.month, {'attr': {'class': attr.widget_class|default('') ~ ''}})~'</div>',
+            '{{ day }}':   '<div class="col-sm-4">'~form_widget(form.day, {'attr': {'class': attr.widget_class|default('') ~ ''}})~'</div>',
         })|raw }}
         </div>
 {% endif %}


### PR DESCRIPTION
With the current solution, no wrapper is added to the select tags of the Year, Month and day. Therefore, we won't be able to have inline items.
To fix this issue, I proposed adding the wrappers manually with the class "col-sm-4" and I removed the "horizontal_input_wrapper_class" attribute