### PR TITLE
Give a way for SASS 3.2 to use base templates correctly.

### DIFF
--- a/Resources/doc/2-base-templates.md
+++ b/Resources/doc/2-base-templates.md
@@ -23,9 +23,10 @@ Templates
 
 Have a look at the provided [base.html.twig](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/views/base.html.twig) its a fully working bootstrap layout for usage without less or sass, and might explain howto use it by itself.
 
-There is also a [base_less.html.twig](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/views/base_less.html.twig) its layout whis less.
+There is also a [base_less.html.twig](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/views/base_less.html.twig) its layout is less.
 
-There is also a [base_sass.html.twig](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/views/base_sass.html.twig) its layout whis sass.
+There is also a [base_sass.html.twig](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/views/base_sass.html.twig) its layout is sass.
+- (If you are using Bootstrap 3.2 for SASS please use base_sass_3.2.html.twig)
 
 There is also a [base_lessjs.html.twig](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/views/base_lessjs.html.twig) with clientside less.js. This is currently not recommended, because you need to setup bootstrap and the less files to use it yourself.
 
@@ -76,7 +77,7 @@ Depending on where your bundle exacly resides (e.g. Your\Smthbundle or Your\Bund
 you need to adapt the path ( ../ ):
 
 ``` css
-// Getting the whole mopabootstrapbundle.less 
+// Getting the whole mopabootstrapbundle.less
 @import "../../../../../../../../mopa/bootstrap-bundle/Mopa/Bundle/BootstrapBundle/Resources/public/less/mopabootstrapbundle.less";
 
 // same for scss files

--- a/Resources/public/sass/mopabootstrapbundle-3.2.scss
+++ b/Resources/public/sass/mopabootstrapbundle-3.2.scss
@@ -1,0 +1,35 @@
+/*!
+ * MopaBootstrapBundle
+ *
+ * Copyright 2011 Mohrenweiser & Partner
+ * Licensed under the Apache License v2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Import this file in your sass files as first to be abled to access sass vars from your file
+ * OR
+ * Add it to the stylesheets of assetic or
+ *
+ * Be careful when using less this way, might be most straight forward, but assetic doesnt check the included files
+ * for changes, and will only regenerate the css if it detects changes in this file!
+ *
+ * For development it might be easier to include all you sass files in the layout directly
+ * But then assetic will compile each sass file in a own compiler session so you cant mix in the sass style into bootstrap, which might not be OK
+ */
+
+// variables
+$icon-font-path: "/bundles/mopabootstrap/fonts/bootstrap/";
+
+// Bootstrap overrides, such as the asset-url(..) function.
+@import "bootstrap_and_overrides";
+
+// Main bootstrap.sass entry point
+@import "../bootstrap-sass/assets/stylesheets/bootstrap";
+
+// The Paginator less for MopaBootstrapBundle
+@import "paginator.scss";
+
+// Collection support for MopaBootstrapBundle
+@import "collections.scss";
+
+// FormFlow support for MopaBootstrapBundle
+@import "form_flow.scss";

--- a/Resources/views/base_sass_3.2.html.twig
+++ b/Resources/views/base_sass_3.2.html.twig
@@ -1,0 +1,25 @@
+{% extends 'MopaBootstrapBundle::base.html.twig' %}
+
+{% block head_style %}
+    {# Override this block to add your own files! #}
+    {% stylesheets
+    '@MopaBootstrapBundle/Resources/public/sass/mopabootstrapbundle-3.2.scss'
+    %}
+    <link href="{{ asset_url }}" type="text/css" rel="stylesheet" media="screen" />
+    {% endstylesheets %}
+    {# To use this without less use the base_css.html.twig template as your base
+     # Be sure you understand whats going on: have a look into
+     # https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/css-vs-less.md
+     #}
+{% endblock head_style %}
+
+{% block foot_script_assetic %}
+    {% javascripts
+    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/assets/javascripts/bootstrap/tooltip.js'
+    '@MopaBootstrapBundle/Resources/public/bootstrap-sass/assets/javascripts/bootstrap/*.js'
+    '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-collection.js'
+    '@MopaBootstrapBundle/Resources/public/js/mopabootstrap-subnav.js'
+    %}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock foot_script_assetic %}


### PR DESCRIPTION
@phiamo We could just do something simple like this for now for people using 3.2+ and then we can switch to the new way in the other branch. What do you think? 