### PR TITLE
Start adding tests. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,21 @@ php:
  
 matrix:
     allow_failures:
-        - php: hhvm
+      - php: hhvm
+    exclude:
+      - php: 5.3
+        env: SYMFONY_VERSION=dev-master
+      - php: 5.4
+        env: SYMFONY_VERSION=dev-master
         
 env:
   - SYMFONY_VERSION=v2.3.0
   - SYMFONY_VERSION=dev-master
 
-before_script: composer require --dev --no-interaction symfony/symfony:${SYMFONY_VERSION}
-script: phpunit
+before_script: 
+  - composer self-update
+  - composer require --dev --no-interaction symfony/symfony:${SYMFONY_VERSION}
+
+script: 
+  - phpunit
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 MopaBootstrapBundle
 ===================
 
+[![Build Status](https://travis-ci.org/phiamo/MopaBootstrapBundle.svg?branch=master)](https://travis-ci.org/phiamo/MopaBootstrapBundle)
+
 MopaBootstrapBundle is a collection of code to integrate twitter's bootstrap
 (http://twitter.github.com/bootstrap/) as easy as possible into your symfony2
 (http://www.symfony.com) Project.
@@ -14,7 +16,7 @@ NOTICE:
 
 Recent BC breaks:
 
- * dc4fd12: [BC Break] Removed inline completely 
+ * dc4fd12: [BC Break] Removed inline completely
  * add75e9: Renamed config mopa_bootstrap.navbar to mopa_bootstrap.menu
  * eb9166f: Pass options in `mopa_bootstrap_render` to the menu provider (unlikely BC)
 
@@ -22,7 +24,7 @@ Recent BC breaks:
 BS3 (master branch of this bundle) is nearly stable see [Beta-4](https://github.com/phiamo/MopaBootstrapBundle/releases/tag/v3.0.0-beta4)
 BS2 (v2.3.x) is quite stable
 
-BC breaking changes will probably not be ported to 2.3. 
+BC breaking changes will probably not be ported to 2.3.
 
 
 Branches
@@ -59,7 +61,7 @@ composer require mopa/bootstrap-bundle:2.3.x-dev twbs/bootstrap:2.3.2
 ```
 
 To understand which versions are currently required have a look into `BRANCHES.md`
- 
+
 Documentation
 -------------
 
@@ -70,7 +72,7 @@ In any case, if something is not working as expected after a update:
 
 Recent BackwardsCompatibility breaking changes:
 
-* c892cd9: Changed the way how navbars are created, read the [doc](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/4-navbar-generation.md) 
+* c892cd9: Changed the way how navbars are created, read the [doc](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/4-navbar-generation.md)
 * a4b78d5: Added Version Detection for BS2 or BS3
 * 5f1200f: Changed the widget_addon form parameter to use type (prepend/append) instead of append (true/false)
 
@@ -96,7 +98,7 @@ Installation instructions are located in the
 Included Features
 -----------------
 
-* Bootstrap Version detection via Composer Bridge 
+* Bootstrap Version detection via Composer Bridge
 * Twig Extensions and templates for use with symfony2 Form component
   * control your form either via the form builder or the template engine
   * control nearly every bootstrap2 form feature

--- a/Tests/Form/AbstractDivLayoutTest.php
+++ b/Tests/Form/AbstractDivLayoutTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Mopa\Bundle\BootstrapBundle\Tests\Form;
+
+use Mopa\Bundle\BootstrapBundle\Form\Extension\ErrorTypeFormTypeExtension;
+use Mopa\Bundle\BootstrapBundle\Form\Extension\HelpFormTypeExtension;
+use Mopa\Bundle\BootstrapBundle\Form\Extension\HorizontalFormTypeExtension;
+use Mopa\Bundle\BootstrapBundle\Form\Extension\LegendFormTypeExtension;
+use Mopa\Bundle\BootstrapBundle\Form\Extension\StaticTextExtension;
+use Mopa\Bundle\BootstrapBundle\Form\Extension\WidgetFormTypeExtension;
+use Mopa\Bundle\BootstrapBundle\Twig\FormExtension as FormExtension2;
+use Mopa\Bundle\BootstrapBundle\Twig\IconExtension;
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Extension\TranslationExtension;
+use Symfony\Bridge\Twig\Form\TwigRenderer;
+use Symfony\Bridge\Twig\Form\TwigRendererEngine;
+use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubTranslator;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\FormIntegrationTestCase;
+
+abstract class AbstractDivLayoutTest extends FormIntegrationTestCase
+{
+    protected $extension;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $rendererEngine = new TwigRendererEngine(array(
+            'form_div_layout.html.twig',
+            'fields.html.twig',
+        ));
+
+        $renderer = new TwigRenderer($rendererEngine, $this->getMock('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface'));
+
+        $this->extension = new FormExtension($renderer);
+
+        $reflection = new \ReflectionClass($renderer);
+        $bridgeDirectory = dirname($reflection->getFileName()).'/../Resources/views/Form';
+
+        $loader = new \Twig_Loader_Filesystem(array(
+            $bridgeDirectory,
+            __DIR__.'/../../Resources/views/Form',
+        ));
+
+        $environment = new \Twig_Environment($loader, array('strict_variables' => true));
+        $environment->addExtension(new TranslationExtension(new StubTranslator()));
+        $environment->addExtension(new IconExtension('fontawesome'));
+        $environment->addExtension(new FormExtension2());
+        $environment->addGlobal('global', '');
+        $environment->addExtension($this->extension);
+
+        $this->extension->initRuntime($environment);
+    }
+
+    protected function getExtensions()
+    {
+        return array(new PreloadedExtension(array(), array(
+            'form' => array(
+                $this->getHelpFormTypeExtension(),
+                $this->getWidgetFormTypeExtension(),
+                $this->getLegendFormTypeExtension(),
+                $this->getHorizontalFormTypeExtension(),
+                $this->getErrorTypeFormTypeExtension(),
+            ),
+            'text' => array(
+                $this->getStaticTextFormTypeExtension(),
+            ),
+        )));
+    }
+
+    protected function getHelpFormTypeExtension()
+    {
+        $popoverOptions = array(
+            'title' => null,
+            'content' => null,
+            'text' => null,
+            'trigger' => 'hover',
+            'toggle' => 'popover',
+            'icon' => 'info-sign',
+            'placement' => 'right',
+            'selector' => null,
+        );
+
+        $tooltipOptions = array(
+            'title' => null,
+            'text' => null,
+            'icon' => 'info-sign',
+            'placement' => 'top',
+        );
+
+        return new HelpFormTypeExtension(array(
+            'help_block_popover' => $popoverOptions,
+            'help_label_popover' => $popoverOptions,
+            'help_widget_popover' => $popoverOptions,
+            'help_block_tooltip' => $tooltipOptions,
+            'help_label_tooltip' => $tooltipOptions,
+        ));
+    }
+
+    protected function getWidgetFormTypeExtension()
+    {
+        return new WidgetFormTypeExtension(array(
+            'checkbox_label' => 'both',
+        ));
+    }
+
+    protected function getLegendFormTypeExtension()
+    {
+        return new LegendFormTypeExtension(array(
+            'render_fieldset' => true,
+            'show_legend' => true,
+            'show_child_legend' => false,
+            'legend_tag' => 'legend',
+            'render_required_asterisk' => false,
+            'render_optional_text' => true,
+        ));
+    }
+
+    protected function getHorizontalFormTypeExtension()
+    {
+        return new HorizontalFormTypeExtension(array(
+            'horizontal' => true,
+            'horizontal_label_class' => 'col-sm-3',
+            'horizontal_label_offset_class' => 'col-sm-offset-3',
+            'horizontal_input_wrapper_class' => 'col-sm-9',
+        ));
+    }
+
+    protected function getErrorTypeFormTypeExtension()
+    {
+        return new ErrorTypeFormTypeExtension(array(
+            'error_type' => null,
+        ));
+    }
+
+    protected function getStaticTextFormTypeExtension()
+    {
+        return new StaticTextExtension();
+    }
+
+    protected function assertMatchesXpath($html, $expression, $count = 1)
+    {
+        $dom = new \DomDocument('UTF-8');
+        try {
+            // Wrap in <root> node so we can load HTML with multiple tags at
+            // the top level
+            $dom->loadXml('<root>'.$html.'</root>');
+        } catch (\Exception $e) {
+            $this->fail(sprintf(
+                "Failed loading HTML:\n\n%s\n\nError: %s",
+                $html,
+                $e->getMessage()
+            ));
+        }
+        $xpath = new \DOMXPath($dom);
+        $nodeList = $xpath->evaluate('/root'.$expression);
+        if ($nodeList->length != $count) {
+            $dom->formatOutput = true;
+            $this->fail(sprintf(
+                "Failed asserting that \n\n%s\n\nmatches exactly %s. Matches %s in \n\n%s",
+                $expression,
+                $count == 1 ? 'once' : $count.' times',
+                $nodeList->length == 1 ? 'once' : $nodeList->length.' times',
+                // strip away <root> and </root>
+                substr($dom->saveHTML(), 6, -8)
+            ));
+        }
+    }
+
+    protected function renderRow(FormView $view, array $vars = array())
+    {
+        return (string) $this->extension->renderer->searchAndRenderBlock($view, 'row', $vars);
+    }
+}

--- a/Tests/Form/AbstractDivLayoutTest.php
+++ b/Tests/Form/AbstractDivLayoutTest.php
@@ -32,7 +32,13 @@ abstract class AbstractDivLayoutTest extends FormIntegrationTestCase
             'fields.html.twig',
         ));
 
-        $renderer = new TwigRenderer($rendererEngine, $this->getMock('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface'));
+        if (interface_exists('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')) {
+            $csrfProviderInterface = 'Symfony\Component\Security\Csrf\CsrfTokenManagerInterface';
+        } else {
+            $csrfProviderInterface = 'Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface';
+        }
+
+        $renderer = new TwigRenderer($rendererEngine, $this->getMock($csrfProviderInterface));
 
         $this->extension = new FormExtension($renderer);
 

--- a/Tests/Form/SimpleDivLayoutTest.php
+++ b/Tests/Form/SimpleDivLayoutTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Mopa\Bundle\BootstrapBundle\Tests\Form;
+
+class SimpleDivLayoutTest extends AbstractDivLayoutTest
+{
+    public function testHorizontalRow()
+    {
+        $view = $this->factory
+            ->createNamed('name', 'email', null, array(
+                'horizontal' => true,
+            ))
+            ->createView()
+        ;
+
+        $html = $this->renderRow($view);
+
+        $this->assertMatchesXpath($html,
+'/div[@class="form-group"]
+    [
+        ./label[@for="name"][@class="control-label col-sm-3 required"]
+        /following-sibling::div[@class="col-sm-9"]
+    ]
+'
+        );
+    }
+}

--- a/Tests/Form/SimpleDivLayoutTest.php
+++ b/Tests/Form/SimpleDivLayoutTest.php
@@ -24,4 +24,24 @@ class SimpleDivLayoutTest extends AbstractDivLayoutTest
 '
         );
     }
+
+    public function testInlineRow()
+    {
+        $view = $this->factory
+            ->createNamed('name', 'text')
+            ->createView()
+        ;
+
+        $html = $this->renderRow($view);
+
+        $this->assertMatchesXpath($html,
+'
+/div[@class="form-group"]
+    [
+        ./label[@for="name"][@class="required"]
+        /following-sibling::input[@type="text"][@id="name"][@name="name"][@required="required"]
+    ]
+'
+        );
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "target-dir": "Mopa/Bundle/BootstrapBundle",
     "require": {
         "symfony/framework-bundle": "~2.3",
-        "symfony/twig-bundle": "~2.3",
-        "symfony/form": "~2.3",
+        "symfony/twig-bundle": "~2.3|~3.0",
+        "symfony/form": "~2.3|~3.0",
         "symfony/console": "~2.3",
         "mopa/composer-bridge": "~1.3"
     },


### PR DESCRIPTION
This works similarly to how Symfony is doing it. It will render the form element and then use XPath to make sure it is rendered correctly. I made an abstract base class so each extension can be overridden to test to make sure the options work. 