### PR TITLE
make $icon-font-path able to override

### DIFF
--- a/Resources/public/sass/mopabootstrapbundle.scss
+++ b/Resources/public/sass/mopabootstrapbundle.scss
@@ -17,7 +17,7 @@
  */
 
 // variables
-$icon-font-path: "/bundles/mopabootstrap/fonts/bootstrap/";
+$icon-font-path: "/bundles/mopabootstrap/fonts/bootstrap/" !default;
 
 // Bootstrap overrides, such as the asset-url(..) function.
 @import "bootstrap_and_overrides";


### PR DESCRIPTION
allow changing `$icon-font-path` within `bootstrap_and_overrides`