### PR TITLE
Replaced dropdown uri with javascript:;

### DIFF
--- a/Menu/Factory/MenuDecorator.php
+++ b/Menu/Factory/MenuDecorator.php
@@ -57,7 +57,7 @@ class MenuDecorator
 
         if ($options['dropdown']) {
             $item
-                ->setUri('#')
+                ->setUri('javascript:;')
                 ->setAttribute('class', 'dropdown')
                 ->setLinkAttribute('class', 'dropdown-toggle')
                 ->setLinkAttribute('data-toggle', 'dropdown')


### PR DESCRIPTION
'#' is giving problems when using hash url's, i.e. w/ AngularJS.
