### PR TITLE
datetimepicker js component and componentReset fix

### DIFF
--- a/Resources/public/components/smalot-bootstrap-datetimepicker/js/bootstrap-datetimepicker.js
+++ b/Resources/public/components/smalot-bootstrap-datetimepicker/js/bootstrap-datetimepicker.js
@@ -55,8 +55,8 @@
 
 		this.bootcssVer = this.isInput ? (this.element.is('.form-control') ? 3 : 2) : ( this.bootcssVer = this.element.is('.input-group') ? 3 : 2 );
 
-		this.component = this.element.is('.date') ? ( this.bootcssVer == 3 ? this.element.find('.input-group-addon .glyphicon-th, .input-group-addon .glyphicon-time, .input-group-addon .glyphicon-calendar').parent() : this.element.find('.add-on .icon-th, .add-on .icon-time, .add-on .icon-calendar').parent()) : false;
-		this.componentReset = this.element.is('.date') ? ( this.bootcssVer == 3 ? this.element.find('.input-group-addon .glyphicon-remove').parent() : this.element.find('.add-on .icon-remove').parent()) : false;
+        this.component = this.element.is('.date') ? ( this.bootcssVer == 3 ? this.element.find('.input-group-addon .glyphicon-th, .input-group-addon .glyphicon-time, .input-group-addon .glyphicon-calendar, .input-group-addon .fa-th, .input-group-addon .fa-clock-o,.input-group-addon .fa-calendar, .input-group-addon .fa-calendar-o').parent() : this.element.find('.add-on .icon-th, .add-on .icon-time, .add-on .icon-calendar').parent()) : false;
+        this.componentReset = this.element.is('.date') ? ( this.bootcssVer == 3 ? this.element.find('.input-group-addon .glyphicon-remove,.input-group-addon .fa-remove').parent() : this.element.find('.add-on .icon-remove').parent()) : false;
 		this.hasInput = this.component && this.element.find('input').length;
 		if (this.component && this.component.length === 0) {
 			this.component = false;


### PR DESCRIPTION
if default icons are fontawesome - make datetimepicker doesn't break and use fontawesome icons to find component and componentReset (by default it is only looking for glyphicon icons)
