### PR TITLE
Reset date icon

### DIFF
--- a/Form/Extension/DateTypeExtension.php
+++ b/Form/Extension/DateTypeExtension.php
@@ -43,8 +43,13 @@ class DateTypeExtension extends AbstractTypeExtension
      */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
-        if ('single_text' === $options['widget'] && isset($options['datepicker'])) {
-            $view->vars['datepicker'] = $options['datepicker'];
+        if ('single_text' === $options['widget']){
+            if (isset($options['datepicker'])) {
+                $view->vars['datepicker'] = $options['datepicker'];
+            }
+            if (isset($options['widget_reset_icon'])) {
+                $view->vars['widget_reset_icon'] = $options['widget_reset_icon'];
+            }
         }
         
         $view->vars['date_wrapper_class'] = $options['date_wrapper_class'];
@@ -57,6 +62,7 @@ class DateTypeExtension extends AbstractTypeExtension
     {
         $resolver->setOptional(array(
             'datepicker',
+            'widget_reset_icon',
         ))->setDefaults(array(
             'date_wrapper_class' => $this->options['date_wrapper_class']
         ));

--- a/Form/Extension/DatetimeTypeExtension.php
+++ b/Form/Extension/DatetimeTypeExtension.php
@@ -28,8 +28,13 @@ class DatetimeTypeExtension extends AbstractTypeExtension
      */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
-        if ('single_text' === $options['widget'] && isset($options['datetimepicker'])) {
-            $view->vars['datetimepicker'] = $options['datetimepicker'];
+        if ('single_text' === $options['widget']) {
+            if (isset($options['datetimepicker'])) {
+                $view->vars['datetimepicker'] = $options['datetimepicker'];
+            }
+            if (isset($options['widget_reset_icon'])) {
+                $view->vars['widget_reset_icon'] = $options['widget_reset_icon'];
+            }
         }
     }
 
@@ -40,6 +45,7 @@ class DatetimeTypeExtension extends AbstractTypeExtension
     {
         $resolver->setOptional(array(
             'datetimepicker',
+            'widget_reset_icon',
         ));
     }
 

--- a/Form/Extension/TimeTypeExtension.php
+++ b/Form/Extension/TimeTypeExtension.php
@@ -28,8 +28,13 @@ class TimeTypeExtension extends AbstractTypeExtension
      */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
-        if ('single_text' === $options['widget'] && isset($options['timepicker'])) {
-            $view->vars['timepicker'] = $options['timepicker'];
+        if ('single_text' === $options['widget']){
+            if (isset($options['timepicker'])) {
+                $view->vars['timepicker'] = $options['timepicker'];
+            }
+            if (isset($options['widget_reset_icon'])) {
+                $view->vars['widget_reset_icon'] = $options['widget_reset_icon'];
+            }
         }
     }
 
@@ -40,6 +45,7 @@ class TimeTypeExtension extends AbstractTypeExtension
     {
         $resolver->setOptional(array(
             'timepicker',
+            'widget_reset_icon',
         ));
     }
 

--- a/Resources/doc/3.3-form-components.md
+++ b/Resources/doc/3.3-form-components.md
@@ -26,6 +26,11 @@ public function buildForm(FormBuilderInterface $builder, array $options)
 }
 ```
 
+If need to add 'reset' button to the field, add to field paremeters array:
+```
+'widget_reset_icon' => true
+```
+
 Configure your form template by adding extended blocks (example for french configuration):
 
 ```jinja

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -280,6 +280,9 @@
         <div data-provider="datepicker" class="input-group date" data-date="{{ value }}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd">
             <input {% if widget_form_control_class is not sameas(false) %}class="{{ widget_form_control_class }}" {% endif %}type="text" {% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if 'placeholder' in attr|keys %} placeholder="{{ attr['placeholder'] }}"{% endif %}>
             <input type="hidden" value="{{ value }}" {{ block('widget_attributes') }}>
+            {% if widget_reset_icon is defined and widget_reset_icon == true %}
+                <span class="input-group-addon">{{ mopa_bootstrap_icon('remove') }}</span>
+            {% endif %}
             <span class="input-group-addon">{{ mopa_bootstrap_icon(widget_addon_icon) }}</span>
         </div>
     {% else %}
@@ -306,6 +309,9 @@
         <div data-provider="timepicker" class="input-group date" data-date="{{ value }}" data-link-field="{{ id }}" data-link-format="hh:ii">
             <input class="form-control" type="text" {% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if 'placeholder' in attr|keys %} placeholder="{{ attr['placeholder'] }}"{% endif %}>
             <input type="hidden" value="{{ value }}" {{ block('widget_attributes') }}>
+            {% if widget_reset_icon is defined and widget_reset_icon == true %}
+                <span class="input-group-addon">{{ mopa_bootstrap_icon('remove') }}</span>
+            {% endif %}
             <span class="input-group-addon">{{ mopa_bootstrap_icon(widget_addon_icon) }}</span>
         </div>
     {% else %}
@@ -334,6 +340,9 @@
             <div data-provider="datetimepicker" class="input-group date" data-date="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd hh:ii">
                 {{ block('form_widget_simple') }}
                 <input type="hidden" value="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" {{ block('widget_attributes') }}>
+                {% if widget_reset_icon is defined and widget_reset_icon == true %}
+                    <span class="input-group-addon">{{ mopa_bootstrap_icon('remove') }}</span>
+                {% endif %}
                 <span class="input-group-addon">{{ mopa_bootstrap_icon(widget_addon_icon) }}</span>
             </div>
         {% else %}


### PR DESCRIPTION
allow to add reset button to date,time,datetime fields

We've discussed this in https://github.com/phiamo/MopaBootstrapBundle/pull/993 but didn't come into conclusion.
Any widget_Addons cannot be used, because the original code, for example for datetimepicker is:
```
<div data-provider="datetimepicker" class="input-group date" data-date="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd hh:ii">
                {{ block('form_widget_simple') }}
                <input type="hidden" value="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" {{ block('widget_attributes') }}>
                <span class="input-group-addon">{{ mopa_bootstrap_icon(widget_addon_icon) }}</span>
            </div>
```
And here is no place to put any widget addons.
