### PR TITLE
Replace 'horizontal' option with 'layout'

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,6 +35,8 @@ class Configuration implements ConfigurationInterface
 
     protected function addFormConfig(ArrayNodeDefinition $rootNode)
     {
+        $layouts = array(false, 'horizontal', 'inline');
+
         $rootNode
             ->children()
                 ->arrayNode('form')
@@ -45,8 +47,10 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('templating')
                             ->defaultValue("MopaBootstrapBundle:Form:fields.html.twig")
                         ->end()
-                        ->booleanNode('horizontal')
-                            ->defaultTrue()
+                        ->enumNode('layout')
+                            ->info('Default form layout')
+                            ->values($layouts)
+                            ->defaultValue('horizontal')
                         ->end()
                         ->scalarNode('horizontal_label_class')
                             ->defaultValue("col-sm-3")
@@ -218,6 +222,17 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                    ->end()
+                    ->beforeNormalization()
+                        ->ifTrue(function ($v) {
+                            return isset($v['horizontal']);
+                        })
+                        ->then(function ($v) {
+                            $v['layout'] = $v['horizontal'] ? 'horizontal' : false;
+                            unset($v['horizontal']);
+
+                            return $v;
+                        })
                     ->end()
                 ->end()
             ->end();

--- a/Form/Extension/LayoutFormTypeExtension.php
+++ b/Form/Extension/LayoutFormTypeExtension.php
@@ -14,15 +14,16 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * Extension for enabling Horizontal Forms.
+ * Extension to customize forms layout.
  *
  * @author phiamo <phiamo@googlemail.com>
  */
-class HorizontalFormTypeExtension extends AbstractTypeExtension
+class LayoutFormTypeExtension extends AbstractTypeExtension
 {
     /**
      * @var array
@@ -44,18 +45,19 @@ class HorizontalFormTypeExtension extends AbstractTypeExtension
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $horizontal = $options['horizontal'];
+        $layout = $options['layout'];
 
-        if ($horizontal === null) {
+        if ($layout === null) {
             if ($view->parent) {
-                $horizontal = $view->parent->vars['horizontal'];
+                $layout = $view->parent->vars['layout'];
             } else {
-                $horizontal = $this->options['horizontal'];
+                $layout = $this->options['layout'];
             }
         }
 
         $view->vars = array_replace($view->vars, array(
-            'horizontal' => $horizontal,
+            'layout' => $layout,
+            'horizontal' => 'horizontal' === $layout, // BC
             'horizontal_label_class' => $options['horizontal_label_class'],
             'horizontal_label_offset_class' => $options['horizontal_label_offset_class'],
             'horizontal_input_wrapper_class' => $options['horizontal_input_wrapper_class'],
@@ -65,9 +67,9 @@ class HorizontalFormTypeExtension extends AbstractTypeExtension
 
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
-        if (!$view->parent && $options['compound'] && $view->vars['horizontal']) {
+        if (!$view->parent && $options['compound'] && $view->vars['layout']) {
             $class = isset($view->vars['attr']['class']) ? $view->vars['attr']['class'].' ' : '';
-            $view->vars['attr']['class'] = $class.'form-horizontal';
+            $view->vars['attr']['class'] = $class.'form-'.$view->vars['layout'];
         }
     }
 
@@ -87,12 +89,28 @@ class HorizontalFormTypeExtension extends AbstractTypeExtension
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
+            'layout' => function (Options $options) {
+                // BC
+                if (isset($options['horizontal']) && false === $options['horizontal']) {
+                    return false;
+                }
+
+                return null;
+            },
             'horizontal' => null,
             'horizontal_label_class' => $this->options['horizontal_label_class'],
             'horizontal_label_offset_class' => $this->options['horizontal_label_offset_class'],
             'horizontal_input_wrapper_class' => $this->options['horizontal_input_wrapper_class'],
             'horizontal_label_div_class' => $this->options['horizontal_label_div_class'],
         ));
+
+        $allowedValues = array(false, null, 'horizontal', 'inline');
+
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $resolver->setAllowedValues('layout', $allowedValues);
+        } else {
+            $resolver->setAllowedValues(array('layout' => $allowedValues)); // SF <2.8 BC
+        }
     }
 
     /**

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -13,7 +13,7 @@
         <parameter key="mopa_bootstrap.form.type_extension.legend.class">Mopa\Bundle\BootstrapBundle\Form\Extension\LegendFormTypeExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.error.class">Mopa\Bundle\BootstrapBundle\Form\Extension\ErrorTypeFormTypeExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.widget.class">Mopa\Bundle\BootstrapBundle\Form\Extension\WidgetFormTypeExtension</parameter>
-        <parameter key="mopa_bootstrap.form.type_extension.horizontal.class">Mopa\Bundle\BootstrapBundle\Form\Extension\HorizontalFormTypeExtension</parameter>
+        <parameter key="mopa_bootstrap.form.type_extension.layout.class">Mopa\Bundle\BootstrapBundle\Form\Extension\LayoutFormTypeExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.widget_collection.class">Mopa\Bundle\BootstrapBundle\Form\Extension\WidgetCollectionFormTypeExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.date.class">Mopa\Bundle\BootstrapBundle\Form\Extension\DateTypeExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.datetime.class">Mopa\Bundle\BootstrapBundle\Form\Extension\DatetimeTypeExtension</parameter>
@@ -89,9 +89,9 @@
             <tag name="form.type_extension" alias="form" extended-type="Symfony\Component\Form\Extension\Core\Type\FormType" />
         </service>
 
-        <service id="mopa_bootstrap.form.type_extension.horizontal" class="%mopa_bootstrap.form.type_extension.horizontal.class%">
+        <service id="mopa_bootstrap.form.type_extension.horizontal" class="%mopa_bootstrap.form.type_extension.layout.class%">
             <argument type="collection">
-                <argument key="horizontal">%mopa_bootstrap.form.horizontal%</argument>
+                <argument key="layout">%mopa_bootstrap.form.layout%</argument>
                 <argument key="horizontal_label_class">%mopa_bootstrap.form.horizontal_label_class%</argument>
                 <argument key="horizontal_label_div_class">%mopa_bootstrap.form.horizontal_label_div_class%</argument>
                 <argument key="horizontal_label_offset_class">%mopa_bootstrap.form.horizontal_label_offset_class%</argument>

--- a/Resources/doc/misc/configuration-reference.md
+++ b/Resources/doc/misc/configuration-reference.md
@@ -8,7 +8,8 @@ mopa_bootstrap:
     form:
         allow_legacy:         false
         templating:           MopaBootstrapBundle:Form:fields.html.twig
-        horizontal:           true
+        # Default form layout
+        layout:               ~ # One of false; "horizontal"
         horizontal_label_class:  col-sm-3 control-label
         horizontal_label_div_class: null
         horizontal_label_offset_class:  col-sm-offset-3

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -36,7 +36,7 @@
                 </div>
             </div>
         {% else %}
-            <div>
+            <div class="form-group">
                 {{ form_widget(form) }}
             </div>
         {% endif %}
@@ -204,6 +204,9 @@
         {% if expanded %}
             {% set attr = attr|merge({'class': attr.class|default('') ~ ' ' ~ horizontal_input_wrapper_class}) %}
         {% endif %}
+        {% if layout is sameas(false) %}
+            <div>
+        {% endif %}
         {% if widget_type == 'inline-btn' %}
             {% set tagName = 'button' %}
             <div class="btn-group" data-toggle="buttons">
@@ -237,6 +240,9 @@
         {% if widget_type == 'inline-btn' %}
             </div>
         {% endif %}
+        {% if layout is sameas(false) %}
+            </div>
+        {% endif %}
     {% endspaceless %}
 {% endblock choice_widget_expanded %}
 
@@ -267,7 +273,7 @@
                 {% endif %}
             {% endif %}
             <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}
-            {%- if not horizontal %} class="checkbox-inline"{% endif %}>
+            {%- if layout == 'inline' %} class="checkbox-inline"{% endif %}>
         {% endif %}
         <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}/>
         {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
@@ -453,7 +459,7 @@
             {% set label_attr = label_attr|merge({'for': id}) %}
         {% endif %}
         {% set label_attr_class = '' %}
-        {% if horizontal %}
+        {% if layout == 'horizontal' %}
             {% set label_attr_class = 'control-label ' ~ label_attr_class ~ horizontal_label_class %}
         {% endif %}
         {% if horizontal_label_div_class %}
@@ -559,7 +565,7 @@
     {% else %}
         {{ block('widget_form_group_start') }}
 
-        {% if horizontal and not label_render %}
+        {% if layout == 'horizontal' and not label_render %}
             {% set horizontal_input_wrapper_class = horizontal_input_wrapper_class ~ ' ' ~ horizontal_label_offset_class %}
         {% endif %}
 

--- a/Tests/Form/AbstractDivLayoutTest.php
+++ b/Tests/Form/AbstractDivLayoutTest.php
@@ -5,7 +5,7 @@ namespace Mopa\Bundle\BootstrapBundle\Tests\Form;
 use Mopa\Bundle\BootstrapBundle\Form\Extension\EmbedFormExtension;
 use Mopa\Bundle\BootstrapBundle\Form\Extension\ErrorTypeFormTypeExtension;
 use Mopa\Bundle\BootstrapBundle\Form\Extension\HelpFormTypeExtension;
-use Mopa\Bundle\BootstrapBundle\Form\Extension\HorizontalFormTypeExtension;
+use Mopa\Bundle\BootstrapBundle\Form\Extension\LayoutFormTypeExtension;
 use Mopa\Bundle\BootstrapBundle\Form\Extension\LegendFormTypeExtension;
 use Mopa\Bundle\BootstrapBundle\Form\Extension\StaticTextExtension;
 use Mopa\Bundle\BootstrapBundle\Form\Extension\TabbedFormTypeExtension;
@@ -105,7 +105,7 @@ abstract class AbstractDivLayoutTest extends FormIntegrationTestCase
                 $this->getHelpFormTypeExtension(),
                 $this->getWidgetFormTypeExtension(),
                 $this->getLegendFormTypeExtension(),
-                $this->getHorizontalFormTypeExtension(),
+                $this->getLayoutFormTypeExtension(),
                 $this->getErrorTypeFormTypeExtension(),
                 $this->getEmbedFormExtension(),
                 $this->getTabbedFormTypeExtension(),
@@ -175,12 +175,12 @@ abstract class AbstractDivLayoutTest extends FormIntegrationTestCase
     }
 
     /**
-     * @return HorizontalFormTypeExtension
+     * @return LayoutFormTypeExtension
      */
-    protected function getHorizontalFormTypeExtension()
+    protected function getLayoutFormTypeExtension()
     {
-        return new HorizontalFormTypeExtension(array(
-            'horizontal' => true,
+        return new LayoutFormTypeExtension(array(
+            'layout' => 'horizontal',
             'horizontal_label_class' => 'col-sm-3',
             'horizontal_label_div_class' => null,
             'horizontal_label_offset_class' => 'col-sm-offset-3',

--- a/Tests/Form/CollectionLayoutTest.php
+++ b/Tests/Form/CollectionLayoutTest.php
@@ -176,8 +176,8 @@ class CollectionLayoutTest extends AbstractDivLayoutTest
         ))
             ->add('names', $this->getFormType('collection'), array(
                 $this->getCollectionTypeKey() => $this->getFormType('text'),
-                $this->getCollectionOptionsKey() => array('horizontal' => true),
-                'horizontal' => false,
+                $this->getCollectionOptionsKey() => array('layout' => 'horizontal'),
+                'layout' => false,
             ))
             ->getForm()
             ->createView()
@@ -261,7 +261,7 @@ class CollectionLayoutTest extends AbstractDivLayoutTest
         ))
             ->add('names', $this->getFormType('collection'), array(
                 $this->getCollectionTypeKey() => $this->getFormType('text'),
-                'horizontal' => false,
+                'layout' => false,
             ))
             ->getForm()
             ->createView()

--- a/Tests/Form/SimpleDivLayoutTest.php
+++ b/Tests/Form/SimpleDivLayoutTest.php
@@ -8,7 +8,7 @@ class SimpleDivLayoutTest extends AbstractDivLayoutTest
     {
         $view = $this->factory
             ->createNamed('name', $this->getFormType('email'), null, array(
-                'horizontal' => true,
+                'layout' => 'horizontal',
             ))
             ->createView()
         ;

--- a/Tests/Form/TypeTestCase.php
+++ b/Tests/Form/TypeTestCase.php
@@ -108,10 +108,10 @@ class TypeTestCase extends KernelTestCase
                     'help_widget_popover' => $this->container->getParameter('mopa_bootstrap.form.help_widget.popover')
                 ]
             ),
-            new MopaExtensions\HorizontalFormTypeExtension(
+            new MopaExtensions\LayoutFormTypeExtension(
                 [
-                    'horizontal' => $this->container->getParameter(
-                        'mopa_bootstrap.form.horizontal'
+                    'layout' => $this->container->getParameter(
+                        'mopa_bootstrap.form.layout'
                     ),
                     'horizontal_label_class' => $this->container->getParameter(
                         'mopa_bootstrap.form.horizontal_label_class'


### PR DESCRIPTION
Currently if you don't want an horizontal form, you have to set `'horizontal' => false`. But afaik, to create an inline form (with the `form-inline` class), you have to do something like : 

```
'horizontal' => false,
'attr' => ['class' => 'form-inline'],
```

Which is not really simple.

This PR add a precise way to choose a `default`, `horizontal` or `inline` layout.
- The bundle `horizontal` configuration option is now replaced with `layout`, which accept `false` (default TWBS layout) or `horizontal` (still default value).
- Same thing with the `horizontal` form option, which also accept the `inline` value.

So, this will give : 

| "layout" value | HTML output |
| --- | --- |
| `false` | `<form ...>` |
| `horizontal` | `<form class="form-horizontal" ...>` |
| `inline` | `<form class="form-inline" ...>` |

I can update my PR to keep BC if necessary.
