### PR TITLE
Fixed FontAwesome3 usage to match FA official documentation

### DIFF
--- a/Resources/public/less/font-awesome/core.less
+++ b/Resources/public/less/font-awesome/core.less
@@ -1,7 +1,7 @@
 // Base Class Definition
 // -------------------------
 
-.@{fa-css-prefix} {
+*[class*="@{fa-css-prefix}-"] {
   display: inline-block;
   font-family: FontAwesome;
   font-style: normal;

--- a/Resources/public/less/font-awesome/variables.less
+++ b/Resources/public/less/font-awesome/variables.less
@@ -3,7 +3,7 @@
 
 @fa-font-path:        @FontAwesomePath;
 //@fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/4.1.0/fonts"; // for referencing Bootstrap CDN font files directly
-@fa-css-prefix:       fa;
+@fa-css-prefix:       icon;
 @fa-version:          "4.1.0";
 @fa-border-color:     #eee;
 @fa-inverse:          #fff;
@@ -512,4 +512,3 @@
 @fa-var-youtube: "\f167";
 @fa-var-youtube-play: "\f16a";
 @fa-var-youtube-square: "\f166";
-


### PR DESCRIPTION
To insert an icon with MopaBootstrapBundle + FontAwesome 3, according to [6-icons.md](https://github.com/phiamo/MopaBootstrapBundle/blob/master/Resources/doc/6-icons.md), we have to use ```{{ icon('pencil') }}```. It generates the following HTML: ```<i class="icon-pencil"></i>``` which is correct regarding to [FontAwesome 3.2.1 - Documentation](http://fontawesome.io/3.2.1/).

However, the MopaBootstrapBundle less source code expect to see ```<i class="fa fa-pencil">```, which is the [FontAwesome 4](http://fontawesome.io//) syntax. As a result, ```{{ icon('pencil') }}``` doesn't work.

Using FontAwesome 3 with FontAwesome 4 syntax ? That is absolutely wrong. The main reason for using Font Awesome 3 and making it available is backward compatibility. So would we break this compatibility ?

This PR fixes this inconsistency.