### PR TITLE
Use alert-dismissible class

### DIFF
--- a/Resources/views/flash.html.twig
+++ b/Resources/views/flash.html.twig
@@ -1,5 +1,5 @@
 {% macro flash(type, message, close, use_raw, class, domain) %}
-    <div class="alert{{ type ? ' alert-'~type : '' }} fade in {{ class|default('') }} {% if close|default(false) %}alert-dismissable{% endif %}">
+    <div class="alert{{ type ? ' alert-'~type : '' }} fade in {{ class|default('') }} {% if close|default(false) %}alert-dismissible{% endif %}">
     {% if close|default(false) %}
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
     {% endif %}
@@ -12,7 +12,7 @@
 {% endmacro %}
 
 {% macro advanced_flash(type, heading, message, close_tag, use_raw, class, domain) %}
-    <div class="alert{{ type ? ' alert-'~type : '' }} fade in {{ class|default('') }} {% if close_tag|default(false) %}alert-dismissable{% endif %}">
+    <div class="alert{{ type ? ' alert-'~type : '' }} fade in {{ class|default('') }} {% if close_tag|default(false) %}alert-dismissible{% endif %}">
     {% if close_tag|default(false) %}
         {% if close_tag == true %}
             {% set close_tag = 'a' %}


### PR DESCRIPTION
According to the official bootlint rule, dismissable alerts must have `alert-dismissible` css class and not `alert-dismissable`.

Related error: https://github.com/twbs/bootlint/wiki/E033

Thanks.