### PR TITLE
Customize datetimepicker, timepicker and datepicker

### DIFF
--- a/Resources/doc/3.3-form-components.md
+++ b/Resources/doc/3.3-form-components.md
@@ -16,7 +16,9 @@ public function buildForm(FormBuilderInterface $builder, array $options)
         ))
         ->add('datetime', null, array(
             'widget' => 'single_text',
-            'datetimepicker' => true,
+            'datetimepicker' => array(
+                'attr' => array('data-start-view' => 'hour')
+            ),
         ))
         ->add('time', null, array(
             'widget' => 'single_text',
@@ -25,6 +27,7 @@ public function buildForm(FormBuilderInterface $builder, array $options)
     ;
 }
 ```
+As you can see for the datetimepicker example, you can pass additional options to the widget and customize it.
 
 Configure your form template by adding extended blocks (example for french configuration):
 

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -277,7 +277,7 @@
 {% if widget == 'single_text' %}
     {% if datepicker is defined %}
         {% set widget_addon_icon = widget_addon_append.icon is defined ? widget_addon_append.icon : 'calendar'  %}
-        <div data-provider="datepicker" class="input-group date" data-date="{{ value }}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd">
+        <div {% if datepicker.attr is defined %}{%- for attrname, attrvalue in datepicker.attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}{% endif %} data-provider="datepicker" class="input-group date" data-date="{{ value }}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd">
             <input {% if widget_form_control_class is not sameas(false) %}class="{{ widget_form_control_class }}" {% endif %}type="text" {% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if 'placeholder' in attr|keys %} placeholder="{{ attr['placeholder'] }}"{% endif %}>
             <input type="hidden" value="{{ value }}" {{ block('widget_attributes') }}>
             <span class="input-group-addon">{{ mopa_bootstrap_icon(widget_addon_icon) }}</span>
@@ -303,7 +303,7 @@
 {% if widget == 'single_text' %}
     {% if timepicker is defined %}
         {% set widget_addon_icon = widget_addon_append.icon is defined ? widget_addon_append.icon : 'time'  %}
-        <div data-provider="timepicker" class="input-group date" data-date="{{ value }}" data-link-field="{{ id }}" data-link-format="hh:ii">
+        <div {% if timepicker.attr is defined %}{%- for attrname, attrvalue in timepicker.attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}{% endif %} data-provider="timepicker" class="input-group date" data-date="{{ value }}" data-link-field="{{ id }}" data-link-format="hh:ii">
             <input class="form-control" type="text" {% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if 'placeholder' in attr|keys %} placeholder="{{ attr['placeholder'] }}"{% endif %}>
             <input type="hidden" value="{{ value }}" {{ block('widget_attributes') }}>
             <span class="input-group-addon">{{ mopa_bootstrap_icon(widget_addon_icon) }}</span>
@@ -331,7 +331,7 @@
     {% if widget == 'single_text' %}
         {% if datetimepicker is defined %}
             {% set widget_addon_icon = widget_addon_append.icon is defined ? widget_addon_append.icon : 'th'  %}
-            <div data-provider="datetimepicker" class="input-group date" data-date="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd hh:ii">
+            <div {% if datetimepicker.attr is defined %}{%- for attrname, attrvalue in datetimepicker.attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}{% endif %} data-provider="datetimepicker" class="input-group date" data-date="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd hh:ii">
                 {{ block('form_widget_simple') }}
                 <input type="hidden" value="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" {{ block('widget_attributes') }}>
                 <span class="input-group-addon">{{ mopa_bootstrap_icon(widget_addon_icon) }}</span>


### PR DESCRIPTION
I have a datetimepicker input field (using smalot-bootstrap-datetimepicker) which I'd like to customize. One of them should have the parameter `startView` set to `hour`.

Your example code to initialize the datetimepicker relies on `data-provider="datetimepicker"`. As all of the datetimepickers will have this provider, I cannot target a specific one. What I'd like to do is setting
```
->add('startTime', 'datetime', array(
    'datetimepicker' => true,
    'attr' => array('data-start-view' => 'hour'),
))
```
Currently this is not possible. As I can see from the form template which renders the different datetimepicker form elements, there is no way to customize the surrounding div. The widget attributes are only applied to the hidden element.
```
<div data-provider="datetimepicker" class="input-group date" data-date="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd hh:ii">
    <input class="form-control" type="text" {% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if 'placeholder' in attr|keys %} placeholder="{{ attr['placeholder'] }}"{% endif %}>
    <input type="hidden" value="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" {{ block('widget_attributes') }}>
    <span class="input-group-addon">{{ mopa_bootstrap_icon(widget_addon_icon) }}</span>
</div>
```
Shouldn't the widget attributes be applied to the surrounding div to allow for customization?

Or maybe something like the following would be nice. I could implement this, if you think this is a good solution:
```
->add('startTime', 'datetime', array(
    'datetimepicker' => array('attr' => array('data-start-view' => 'hour')),
))
```
