### PR TITLE
Extension for displaying 'inline' sub-forms.

### DIFF
--- a/Form/Extension/EmbedFormExtension.php
+++ b/Form/Extension/EmbedFormExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the MopaBootstrapBundle.
+ *
+ * (c) Philipp A. Mohrenweiser <phiamo@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
+
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+/**
+ * Extension for displaying 'inline' sub-forms.
+ *
+ * @author peshi <peshis@gmail.com>
+ */
+class EmbedFormExtension extends AbstractTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return 'form';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(
+            array(
+                'embed_form' => null,
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['embed_form'] = $options['embed_form'];
+    }
+}

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -5,6 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
+        <parameter key="mopa_bootstrap.form.type_extension.embed_form.class">Mopa\Bundle\BootstrapBundle\Form\Extension\EmbedFormExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.static_text.class">Mopa\Bundle\BootstrapBundle\Form\Extension\StaticTextExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.offset_button.class">Mopa\Bundle\BootstrapBundle\Form\Extension\OffsetButtonExtension</parameter>
         <parameter key="mopa_bootstrap.form.type_extension.button.class">Mopa\Bundle\BootstrapBundle\Form\Extension\IconButtonExtension</parameter>
@@ -23,6 +24,10 @@
     </parameters>
 
     <services>
+        <service id="mopa_bootstrap.form.type_extension.embed_form" class="%mopa_bootstrap.form.type_extension.embed_form.class%">
+            <tag name="form.type_extension" alias="form" />
+        </service>
+
         <service id="mopa_bootstrap.form.type_extension.static_text" class="%mopa_bootstrap.form.type_extension.static_text.class%">
             <tag name="form.type_extension" alias="form" />
         </service>

--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -513,6 +513,8 @@
 {% spaceless %}
     {% if 'tab' in form.vars.block_prefixes %}
         {{ block('form_tab') }}
+    {% elseif embed_form is sameas(true) %}
+        {{ widget_prefix|trans({}, translation_domain)|raw }} {{ form_widget(form, _context) }} {{ widget_suffix|trans({}, translation_domain)|raw }}
     {% else %}
         {{ block('widget_form_group_start') }}
 


### PR DESCRIPTION
Adds the ability for displaying 'inline' sub-forms as discussed in https://github.com/phiamo/MopaBootstrapBundle/issues/862

From:
http://symfony.com/doc/current/book/forms.html#embedding-a-single-object

Usage example:
```
        $builder->add('parentForm1', 'text', array(
            'mapped' => false,
        ));
        $builder->add('parentForm2', 'text', array(
            'mapped' => false,
        ));
        $builder->add('settings', new SettingsFormType(), array(
            'embed_form' => true,
        ));
        $builder->add('parentForm3', 'text', array(
            'mapped' => false,
        ));
        $builder->add('parentForm4', 'text', array(
            'mapped' => false,
        ));
```