### PR TITLE
Travis improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3.3
+    - php: 5.3.4
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3.4
+    - php: 5.3
       env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,51 @@
 language: php
+
 php:
   - 5.3
   - 5.4
   - 5.5
   - 5.6
   - hhvm
- 
-matrix:
-    allow_failures:
-      - php: hhvm
-    exclude:
-      - php: 5.3
-        env: SYMFONY_VERSION=dev-master
-      - php: 5.4
-        env: SYMFONY_VERSION=dev-master
-        
+  - nightly
+
 env:
-  - SYMFONY_VERSION=v2.3.0
-  - SYMFONY_VERSION=dev-master
+  - SYMFONY_VERSION=2.6.*
 
-before_script: 
-  - composer self-update
-  - composer require --dev --no-interaction symfony/symfony:${SYMFONY_VERSION}
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.3.3
+      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.4.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.5.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.6.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION="3.0.x-dev as 2"
+  allow_failures:
+    - php: hhvm
+    - php: nightly
+    - env: SYMFONY_VERSION=2.7.*@dev
+    - env: SYMFONY_VERSION=2.8.*@dev
+    - env: SYMFONY_VERSION="3.0.x-dev as 2"
 
-script: 
-  - phpunit
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
 
+before_script:
+  - composer selfupdate
+  - composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update
+  - composer update --prefer-dist $COMPOSER_FLAGS
+
+script:
+  - php vendor/bin/phpunit -c phpunit.xml.dist

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         "symfony/console": "~2.3",
         "mopa/composer-bridge": "~1.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.6",
+    },
     "suggest":  {
         "twbs/bootstrap": ">2.0,<4.0-dev",
         "knplabs/knp-paginator-bundle": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/twig-bundle": "~2.3|~3.0",
         "symfony/form": "~2.3|~3.0",
         "symfony/console": "~2.3",
+        "twig/twig": ">=1.12",
         "mopa/composer-bridge": "~1.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "mopa/composer-bridge": "~1.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.6",
+        "phpunit/phpunit": "~4.6"
     },
     "suggest":  {
         "twbs/bootstrap": ">2.0,<4.0-dev",


### PR DESCRIPTION
This PR is a Travis improvement suggestion.

With this new config, we have:

 * Tests from php 5.3 to 5.6
 * Tests form SF 2.3 to 2.6 and 2.7/2.8/3.0 allowed failure
 * Vendor phpunit bin
 * Cache system to make tests quicker

I'm waiting your review. :+1: 