### PR TITLE
Fixing label_attr for widget_type inline-btn and fixing form_errors

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -210,7 +210,7 @@
                 {%- if widget_type == 'inline-btn' %} class="btn-group" data-toggle="buttons"{% endif %}>
             {% endif %}
             {% if widget_type == 'inline-btn' %}
-                {% set label_attr = attr|default({})|merge({'class': 'btn ' ~ attr.class|default('')}) %}
+                {% set label_attr = label_attr|default({})|merge({'class': 'btn ' ~ label_attr.class|default('')}) %}
             {% endif %}
             {% if child.vars.checked and widget_type == 'inline-btn' %}
                 {% set label_attr_copy = label_attr|default({})|merge({'class': 'active ' ~ label_attr.class|default('')}) %}
@@ -513,7 +513,7 @@
 
 {% block form_rows_visible %}
 {% spaceless %}
-    {% if form_errors(form) %}
+     {% if errors|length > 0 %}
         <div class="symfony-form-errors">
             {{ form_errors(form) }}
         </div>


### PR DESCRIPTION
There are problems related to label_attr if field.html.twig, it also existing in your demo site: ![demo-site](http://f5.s.qip.ru/BtVUonic.png)
Also, `form_errors(from)` are rendering errors and not returning them.