### PR TITLE
Replace deprecated setOptional with setDefined

### DIFF
--- a/Form/Extension/DateTypeExtension.php
+++ b/Form/Extension/DateTypeExtension.php
@@ -71,7 +71,7 @@ class DateTypeExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(array(
+        $resolver->setDefined(array(
             'datepicker',
             'widget_reset_icon',
         ))->setDefaults(array(

--- a/Form/Extension/DateTypeExtension.php
+++ b/Form/Extension/DateTypeExtension.php
@@ -14,6 +14,7 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -71,10 +72,19 @@ class DateTypeExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefined(array(
-            'datepicker',
-            'widget_reset_icon',
-        ))->setDefaults(array(
+        if (version_compare(Kernel::VERSION, '2.6', '<')) {
+            $resolver->setOptional(array(
+                'datepicker',
+                'widget_reset_icon',
+            ));
+        } else {
+            $resolver->setDefined(array(
+                'datepicker',
+                'widget_reset_icon',
+            ));
+        }
+
+        $resolver->setDefaults(array(
             'date_wrapper_class' => $this->options['date_wrapper_class']
         ));
     }

--- a/Form/Extension/DatetimeTypeExtension.php
+++ b/Form/Extension/DatetimeTypeExtension.php
@@ -14,6 +14,7 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -54,10 +55,17 @@ class DatetimeTypeExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefined(array(
-            'datetimepicker',
-            'widget_reset_icon',
-        ));
+        if (version_compare(Kernel::VERSION, '2.6', '<')) {
+            $resolver->setOptional(array(
+                'datetimepicker',
+                'widget_reset_icon',
+            ));
+        } else {
+            $resolver->setDefined(array(
+                'datetimepicker',
+                'widget_reset_icon',
+            ));
+        }
     }
 
     /**

--- a/Form/Extension/DatetimeTypeExtension.php
+++ b/Form/Extension/DatetimeTypeExtension.php
@@ -54,7 +54,7 @@ class DatetimeTypeExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(array(
+        $resolver->setDefined(array(
             'datetimepicker',
             'widget_reset_icon',
         ));

--- a/Form/Extension/TimeTypeExtension.php
+++ b/Form/Extension/TimeTypeExtension.php
@@ -14,6 +14,7 @@ namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -54,10 +55,17 @@ class TimeTypeExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefined(array(
-            'timepicker',
-            'widget_reset_icon',
-        ));
+        if (version_compare(Kernel::VERSION, '2.6', '<')) {
+            $resolver->setOptional(array(
+                'timepicker',
+                'widget_reset_icon',
+            ));
+        } else {
+            $resolver->setDefined(array(
+                'timepicker',
+                'widget_reset_icon',
+            ));
+        }
     }
 
     /**

--- a/Form/Extension/TimeTypeExtension.php
+++ b/Form/Extension/TimeTypeExtension.php
@@ -54,7 +54,7 @@ class TimeTypeExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(array(
+        $resolver->setDefined(array(
             'timepicker',
             'widget_reset_icon',
         ));


### PR DESCRIPTION
Per Symfony: "The Symfony\Component\OptionsResolver\OptionsResolver::setOptional method is deprecated since version 2.6 and will be removed in 3.0. Use the setDefined() method instead."