### PR TITLE
Use method_exists on resolver instead of version_compare

### DIFF
--- a/Form/Extension/DateTypeExtension.php
+++ b/Form/Extension/DateTypeExtension.php
@@ -72,13 +72,13 @@ class DateTypeExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        if (version_compare(Kernel::VERSION, '2.6', '<')) {
-            $resolver->setOptional(array(
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setDefined(array(
                 'datepicker',
                 'widget_reset_icon',
             ));
-        } else {
-            $resolver->setDefined(array(
+        } else { // Symfony <2.6 BC
+            $resolver->setOptional(array(
                 'datepicker',
                 'widget_reset_icon',
             ));

--- a/Form/Extension/DatetimeTypeExtension.php
+++ b/Form/Extension/DatetimeTypeExtension.php
@@ -55,13 +55,13 @@ class DatetimeTypeExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        if (version_compare(Kernel::VERSION, '2.6', '<')) {
-            $resolver->setOptional(array(
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setDefined(array(
                 'datetimepicker',
                 'widget_reset_icon',
             ));
-        } else {
-            $resolver->setDefined(array(
+        } else { // Symfony <2.6 BC
+            $resolver->setOptional(array(
                 'datetimepicker',
                 'widget_reset_icon',
             ));

--- a/Form/Extension/TimeTypeExtension.php
+++ b/Form/Extension/TimeTypeExtension.php
@@ -55,13 +55,13 @@ class TimeTypeExtension extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        if (version_compare(Kernel::VERSION, '2.6', '<')) {
-            $resolver->setOptional(array(
+        if (method_exists($resolver, 'setDefined')) {
+            $resolver->setDefined(array(
                 'timepicker',
                 'widget_reset_icon',
             ));
-        } else {
-            $resolver->setDefined(array(
+        } else { // Symfony <2.6 BC
+            $resolver->setOptional(array(
                 'timepicker',
                 'widget_reset_icon',
             ));


### PR DESCRIPTION
This is a fix of #1074 made by @sgilberg.

`version_compare` on kernel **must not** be used as possible because kernel dependency version could be different of framework-bundle.

`method_exists` is more reliable.

Regards