### PR TITLE
Fixes

### DIFF
--- a/Command/BaseBootstrapSymlinkCommand.php
+++ b/Command/BaseBootstrapSymlinkCommand.php
@@ -102,7 +102,7 @@ abstract class BaseBootstrapSymlinkCommand extends ContainerAwareCommand
         $filesystem = new Filesystem();
         $filesystem->mkdir($symlinkName);
         $filesystem->mirror(
-            realpath($symlinkName.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.$symlinkTarget),
+            realpath($symlinkTarget),
             $symlinkName,
             null,
             array('copy_on_windows' => true, 'delete' => true, 'override' => true)

--- a/Resources/public/sass/mopabootstrapbundle.scss
+++ b/Resources/public/sass/mopabootstrapbundle.scss
@@ -23,7 +23,7 @@ $icon-font-path: "/bundles/mopabootstrap/fonts/bootstrap/" !default;
 @import "bootstrap_and_overrides";
 
 // Main bootstrap.sass entry point
-@import "../bootstrap-sass/assets/stylesheets/bootstrap/bootstrap";
+@import "../bootstrap-sass/assets/stylesheets/bootstrap";
 
 // The Paginator less for MopaBootstrapBundle
 @import "paginator.scss";


### PR DESCRIPTION
The first line change there is a fail on windows I think.. at least for me it was producing something like `C:/foo/bar/baz/../C:/foo/bar/baz` which is two absolute paths put together and after a realpath() you get false and it tries to mirror nothing into something which fails.

The second line I don't really get it if it's a change depending on the bootstrap version or what, but for me that path is just invalid there is one bootstrap too many. Please check though..