### PR TITLE
Fix degradation of fontawesome4 font path

### DIFF
--- a/Resources/public/less/font-awesome4/variables.less
+++ b/Resources/public/less/font-awesome4/variables.less
@@ -1,7 +1,7 @@
 // Variables
 // --------------------------
 
-@fa-font-path:        "../fonts";
+@fa-font-path:        @FontAwesomePath;
 //@fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/4.2.0/fonts"; // for referencing Bootstrap CDN font files directly
 @fa-css-prefix:       fa;
 @fa-version:          "4.2.0";


### PR DESCRIPTION
Fixing fontawesome4 font path in [#934](https://github.com/phiamo/MopaBootstrapBundle/pull/934/files#diff-772526fd3f5419b7924fdfd048754f8eR4) is broken by [#973](https://github.com/phiamo/MopaBootstrapBundle/pull/973/files#diff-772526fd3f5419b7924fdfd048754f8eR4). This PR fixes this degradation.
Thanks.