### PR TITLE
fix static_text symfony 2.8

### DIFF
--- a/Form/Extension/StaticTextExtension.php
+++ b/Form/Extension/StaticTextExtension.php
@@ -29,7 +29,7 @@ class StaticTextExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'text';
+        return 'form';
     }
 
     /**


### PR DESCRIPTION
Came across an error when using symfony 2.8, this fixes the issue.

```
The extended type specified for the service "mopa_bootstrap.form.type_extension.static_text" does not match the actual extended type. Expected "form", given "text".
```