### PR TITLE
Refactored deprecations of latest symfony and twig releases

### DIFF
--- a/Form/Extension/DateTypeExtension.php
+++ b/Form/Extension/DateTypeExtension.php
@@ -1,7 +1,7 @@
 <?php
 namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -25,11 +25,9 @@ class DateTypeExtension extends AbstractTypeExtension
 
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setOptional(array(
-            'datepicker'
-        ));
+        $resolver->setDefined('datepicker');
     }
 
     public function getExtendedType()

--- a/Form/Extension/ErrorTypeFormTypeExtension.php
+++ b/Form/Extension/ErrorTypeFormTypeExtension.php
@@ -1,7 +1,7 @@
 <?php
 namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -19,7 +19,7 @@ class ErrorTypeFormTypeExtension extends AbstractTypeExtension
         $view->vars['error_type'] = $options['error_type'];
         $view->vars['error_delay'] = $options['error_delay'];
     }
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'error_type' => $this->error_type,

--- a/Form/Extension/HelpFormTypeExtension.php
+++ b/Form/Extension/HelpFormTypeExtension.php
@@ -1,8 +1,7 @@
 <?php
 namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -65,7 +64,7 @@ class HelpFormTypeExtension extends AbstractTypeExtension
         }
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'help_inline' => null,

--- a/Form/Extension/IconButtonExtension.php
+++ b/Form/Extension/IconButtonExtension.php
@@ -1,12 +1,10 @@
 <?php
 namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 
 class IconButtonExtension extends AbstractTypeExtension
 {
@@ -21,7 +19,7 @@ class IconButtonExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(

--- a/Form/Extension/LegendFormTypeExtension.php
+++ b/Form/Extension/LegendFormTypeExtension.php
@@ -1,7 +1,7 @@
 <?php
 namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -35,7 +35,7 @@ class LegendFormTypeExtension extends AbstractTypeExtension
         $view->vars['render_optional_text'] = $options['render_optional_text'];
         $view->vars['errors_on_forms'] = $options['errors_on_forms'];
     }
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'render_fieldset' => $this->render_fieldset,

--- a/Form/Extension/TabbedFormTypeExtension.php
+++ b/Form/Extension/TabbedFormTypeExtension.php
@@ -1,7 +1,7 @@
 <?php
 namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -30,7 +30,7 @@ class TabbedFormTypeExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'tabs_class' => $this->options['class'],

--- a/Form/Extension/WidgetCollectionFormTypeExtension.php
+++ b/Form/Extension/WidgetCollectionFormTypeExtension.php
@@ -1,7 +1,7 @@
 <?php
 namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -63,7 +63,7 @@ class WidgetCollectionFormTypeExtension extends AbstractTypeExtension
         $view->vars['widget_remove_btn'] = $options['widget_remove_btn'];
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'omit_collection_item' => true === $this->options['render_collection_item'] ? false : true,

--- a/Form/Extension/WidgetFormTypeExtension.php
+++ b/Form/Extension/WidgetFormTypeExtension.php
@@ -1,11 +1,11 @@
 <?php
 namespace Mopa\Bundle\BootstrapBundle\Form\Extension;
 
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\Exception\CreationException;
+use Symfony\Component\Form\Exception\RuntimeException;
 
 class WidgetFormTypeExtension extends AbstractTypeExtension
 {
@@ -19,7 +19,7 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         if (!is_array($options['widget_addon'])) {
-            throw new CreationException("The 'widget_addon' option must be an array");
+            throw new RuntimeException("The 'widget_addon' option must be an array");
         }
         if (in_array('percent', $view->vars['block_prefixes'])) {
             if ($options['widget_addon']['type'] === null) {
@@ -48,7 +48,7 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
         $view->vars['widget_checkbox_label'] = $options['widget_checkbox_label'];
 
     }
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -68,16 +68,21 @@ class WidgetFormTypeExtension extends AbstractTypeExtension
                 'widget_checkbox_label' => $this->options['checkbox_label'],
             )
         );
-        $resolver->setAllowedValues(array(
-                'widget_type' => array(
-                    'inline',
-                    '',
-                ),
-                'widget_checkbox_label' => array(
-                    'label',
-                    'widget',
-                    'both',
-                )
+
+        $resolver->setAllowedValues(
+            'widget_type',
+            array(
+                'inline',
+                '',
+            )
+        );
+
+        $resolver->setAllowedValues(
+            'widget_checkbox_label',
+            array(
+                'label',
+                'widget',
+                'both',
             )
         );
     }

--- a/Navbar/Twig/NavbarExtension.php
+++ b/Navbar/Twig/NavbarExtension.php
@@ -18,7 +18,7 @@ class NavbarExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'mopa_bootstrap_navbar' => new \Twig_Function_Method($this, 'render', array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('mopa_bootstrap_navbar', array($this, 'render'), array('is_safe' => array('html')))
         );
     }
 

--- a/Twig/MopaBootstrapInitializrTwigExtension.php
+++ b/Twig/MopaBootstrapInitializrTwigExtension.php
@@ -20,8 +20,6 @@ class MopaBootstrapInitializrTwigExtension extends \Twig_Extension
 {
     protected $container;
 
-    protected $environment;
-
     /**
      *
      * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
@@ -29,15 +27,6 @@ class MopaBootstrapInitializrTwigExtension extends \Twig_Extension
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
-    }
-
-    /**
-     *
-     * @param \Twig_Environment $environment
-     */
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->environment = $environment;
     }
 
     /**

--- a/Twig/MopaBootstrapInitializrTwigExtension.php
+++ b/Twig/MopaBootstrapInitializrTwigExtension.php
@@ -71,7 +71,7 @@ class MopaBootstrapInitializrTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'form_help' => new \Twig_Function_Node('Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('form_help', 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
         );
     }
     

--- a/Twig/MopaBootstrapTwigExtension.php
+++ b/Twig/MopaBootstrapTwigExtension.php
@@ -48,8 +48,8 @@ class MopaBootstrapTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'form_help' => new \Twig_Function_Node('Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
-            'form_tabs' => new \Twig_Function_Node('Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('form_help', 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('form_tabs', 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
         );
     }
 

--- a/Twig/MopaBootstrapTwigExtension.php
+++ b/Twig/MopaBootstrapTwigExtension.php
@@ -19,27 +19,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class MopaBootstrapTwigExtension extends \Twig_Extension
 {
-    protected $container;
-
-    protected $environment;
-
-    /**
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-     */
-    public function __construct(ContainerInterface $container)
-    {
-        $this->container = $container;
-    }
-
-    /**
-     *
-     * @param \Twig_Environment $environment
-     */
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->environment = $environment;
-    }
     /**
      * Returns a list of functions to add to the existing list.
      *

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "target-dir": "Mopa/Bundle/BootstrapBundle",
     "require": {
-        "symfony/symfony": "~2.3",
+        "symfony/symfony": "~2.7",
+        "twig/twig": "~1.21",
         "mopa/composer-bridge": "1.3.*"
     },
     "suggest":  {


### PR DESCRIPTION
I did some small refactorings to update to comply with Symfony 2.7 and the upcoming Twig 2.0 release and to avoid the deprecation warnings.

It would be great if this could be merged and a new release could be created.