### PR TITLE
[WIP] composer: use PSR-4 autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "Mopa\\Bundle\\BootstrapBundle\\": ""
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
         "mopa/composer-bridge": "~1.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.6"
+        "phpunit/phpunit": "~4.6",
+        "twbs/bootstrap": ">2.0,<4.0-dev"
     },
     "conflict": {
         "symfony/twig-bridge": "<2.3"
     },
     "suggest":  {
-        "twbs/bootstrap": ">2.0,<4.0-dev",
         "knplabs/knp-paginator-bundle": "~2.3",
         "knplabs/knp-menu-bundle": "~2.0@dev",
         "mopa/bootstrap-sandbox-bundle": "~2.3",


### PR DESCRIPTION
PSR-0 is deprecated over a year

This actually fixes autoloading of ScriptHandler, that is not loaded with PSR-0: [see travils message](https://travis-ci.org/phiamo/MopaBootstrapBundle/jobs/92567506#L209)