### PR TITLE
travis: drop phpunit default configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
   - composer update --prefer-dist $COMPOSER_FLAGS
 
 script:
-  - php vendor/bin/phpunit -c phpunit.xml.dist
+  - vendor/bin/phpunit
 
 after_success:
   - coveralls


### PR DESCRIPTION
File `phpunit.xml.dist` is loaded by default, if `phpunit.xml` is not present.