### PR TITLE
Fix bad alias on static_text type extension

### DIFF
--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -29,7 +29,7 @@
         </service>
 
         <service id="mopa_bootstrap.form.type_extension.static_text" class="%mopa_bootstrap.form.type_extension.static_text.class%">
-            <tag name="form.type_extension" alias="form" />
+            <tag name="form.type_extension" alias="text" />
         </service>
 
         <service id="mopa_bootstrap.form.type_extension.offset_button" class="%mopa_bootstrap.form.type_extension.offset_button.class%">


### PR DESCRIPTION
This fix the following error on SF 2.8:

```
Symfony\Component\Form\Exception\InvalidArgumentException: The extended type specified for the service "mopa_bootstrap.form.type_extension.static_text" does not match the actual extended type. Expected "form", given "text".
```

Related issue: https://github.com/symfony/symfony/issues/16045