### PR TITLE
Use choice_translation_domain option

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -220,9 +220,9 @@
             <label{% for attrname, attrvalue in label_attr_copy %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
             {{ form_widget(child, {'horizontal_label_class': horizontal_label_class, 'horizontal_input_wrapper_class': horizontal_input_wrapper_class, 'attr': {'class': attr.widget_class|default('') }}) }}
             {% if widget_type == 'inline-btn' or widget_checkbox_label == 'widget'%}
-                {{ child.vars.label|trans({}, translation_domain)|raw }}
+                {{ child.vars.label|trans({}, choice_translation_domain|default(translation_domain))|raw }}
             {% else %}
-                {{ child.vars.label|trans({}, translation_domain) }}
+                {{ child.vars.label|trans({}, choice_translation_domain|default(translation_domain)) }}
             {% endif %}
             </label>
             {% if widget_type not in ['inline', 'inline-btn'] %}
@@ -267,7 +267,7 @@
         {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
             {% if label_render %}
                 {% if widget_checkbox_label in ['both', 'widget'] %}
-                    {{ label|trans({}, translation_domain)|raw }}
+                    {{ label|trans({}, choice_translation_domain|default(translation_domain))|raw }}
                 {% else %}
                     {{ block('form_help') }}
                 {% endif %}


### PR DESCRIPTION
This PR adds support of the sf2.7 option `choice_translation_domain` (see http://symfony.com/blog/new-in-symfony-2-7-form-and-validator-updates#added-choice-translation-domain-domain-to-avoid-translating-options).

For older sf version, there is a fallback to the old `translation_domain`.