### PR TITLE
Allow parent of dropdown be a real link

### DIFF
--- a/Menu/Factory/MenuDecorator.php
+++ b/Menu/Factory/MenuDecorator.php
@@ -56,8 +56,11 @@ class MenuDecorator
         }
 
         if ($options['dropdown']) {
+            if ($item->getUri() == "") {
+                $item->setUri('#');
+            }
+            
             $item
-                ->setUri('#')
                 ->setAttribute('class', trim('dropdown '.$item->getAttribute('class')))
                 ->setLinkAttribute('class', 'dropdown-toggle')
                 ->setLinkAttribute('data-toggle', 'dropdown')


### PR DESCRIPTION
When changing the behaviour of the menu (eg. open on hover), it should be allowed for the parent of a dropdown to have a URI instead of forcing to `href="#"`

Example: (--> About)
http://vadikom.github.io/smartmenus/src/demo/index.html