### PR TITLE
InitializrTwigExtension deprecation warning suppressed

### DIFF
--- a/Twig/InitializrTwigExtension.php
+++ b/Twig/InitializrTwigExtension.php
@@ -17,7 +17,7 @@ namespace Mopa\Bundle\BootstrapBundle\Twig;
  *
  * @author Paweł Madej (nysander) <pawel.madej@profarmaceuta.pl>
  */
-class InitializrTwigExtension extends \Twig_Extension
+class InitializrTwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
     /**
      * @var array


### PR DESCRIPTION
InitializrTwigExtension should implement Twig_Extension_GlobalsInterface to suppress the deprecation warning.