### PR TITLE
fiedls.html.twig modification to solve issue on datetimepicker

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -287,7 +287,7 @@
 {% if widget == 'single_text' %}
     {% if datepicker is defined %}
         {% set widget_addon_icon = widget_addon_append.icon is defined ? widget_addon_append.icon : 'calendar'  %}
-        <div {% if datepicker.attr is defined %}{%- for attrname, attrvalue in datepicker.attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}{% endif %} data-provider="datepicker" class="input-group date" data-date="{{ value }}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd">
+        <div {% if datepicker.attr is defined %}{%- for attrname, attrvalue in datepicker.attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}{% endif %} data-provide="datepicker" class="input-group date" data-date="{{ value }}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd">
             <input type="hidden" value="{{ value }}" {{ block('widget_attributes') }}>
             {% if widget_reset_icon is defined and widget_reset_icon == true %}
                 <span class="input-group-addon">{{ mopa_bootstrap_icon('remove') }}</span>
@@ -320,7 +320,7 @@
 {% if widget == 'single_text' %}
     {% if timepicker is defined %}
         {% set widget_addon_icon = widget_addon_append.icon is defined ? widget_addon_append.icon : 'time'  %}
-        <div {% if timepicker.attr is defined %}{%- for attrname, attrvalue in timepicker.attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}{% endif %} data-provider="timepicker" class="input-group date" data-date="{{ value }}" data-link-field="{{ id }}" data-link-format="hh:ii">
+        <div {% if timepicker.attr is defined %}{%- for attrname, attrvalue in timepicker.attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}{% endif %} data-provide="timepicker" class="input-group date" data-date="{{ value }}" data-link-field="{{ id }}" data-link-format="hh:ii">
             <input type="hidden" value="{{ value }}" {{ block('widget_attributes') }}>
             {% if widget_reset_icon is defined and widget_reset_icon == true %}
                 <span class="input-group-addon">{{ mopa_bootstrap_icon('remove') }}</span>
@@ -355,7 +355,7 @@
     {% if widget == 'single_text' %}
         {% if datetimepicker is defined %}
             {% set widget_addon_icon = widget_addon_append.icon is defined ? widget_addon_append.icon : 'th'  %}
-            <div {% if datetimepicker.attr is defined %}{%- for attrname, attrvalue in datetimepicker.attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}{% endif %} data-provider="datetimepicker" class="input-group date" data-date="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd hh:ii">
+            <div {% if datetimepicker.attr is defined %}{%- for attrname, attrvalue in datetimepicker.attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}{% endif %} data-provide="datetimepicker" class="input-group date" data-date="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" data-link-field="{{ id }}" data-link-format="yyyy-mm-dd hh:ii">
                 <input type="hidden" value="{% if value %}{{ value|date('Y-m-d H:i') }}{% endif %}" {{ block('widget_attributes') }}>
                 {% if widget_reset_icon is defined and widget_reset_icon == true %}
                     <span class="input-group-addon">{{ mopa_bootstrap_icon('remove') }}</span>

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mopa/bootstrap-bundle",
+    "name": "apoill19/mopa/bootstrap-bundle",
     "type": "symfony-bundle",
     "description": "Easy integration of twitters bootstrap into symfony2",
     "keywords": ["form", "extra form", "bootstrap", "bootstrap form", "template"],


### PR DESCRIPTION
Hi,

I've tried to use a "datetimepicker" in a formtype, but it doesn't work.

I think issue come from the 'fiedls.html.twig'. In the **{% block datetime_widget %}**, the datetimepicker is set with 'data-provide**_R_**' attribute. But, in the **"bootstrap-datetimepicker.js"**, the action on click is linked with 'data-provide' attribute (code below)

```
/* DATETIMEPICKER DATA-API
	 * ================== */
	$(document).on(
		'focus.datetimepicker.data-api click.datetimepicker.data-api',
		'[data-provide="datetimepicker"]',
		function (e) {
			var $this = $(this);
			if ($this.data('datetimepicker')) return;
			e.preventDefault();
			// component click requires us to explicitly show it
			$this.datetimepicker('show');
		}
	);
	$(function () {
		$('[data-provide="datetimepicker-inline"]').datetimepicker();
	});

```

I'm a beginner and this is my first 'pull request'. So, don't hesitate to tell me if I'm doing wrong.

Thanks.