### PR TITLE
Trim money_pattern to prevent leading spaces in translation keys

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -391,7 +391,7 @@
 
 {% block money_widget %}
 {% spaceless %}
-    {% set widget_addon_prepend = (widget_addon_prepend != false or widget_addon_prepend == null) and money_pattern != '{{ widget }}' ? {'text': money_pattern|replace({ '{{ widget }}': ''})} : widget_addon_prepend|default(null) %}
+    {% set widget_addon_prepend = (widget_addon_prepend != false or widget_addon_prepend == null) and money_pattern != '{{ widget }}' ? {'text': money_pattern|replace({ '{{ widget }}': ''})|trim} : widget_addon_prepend|default(null) %}
     {{ block('form_widget_simple') }}
 {% endspaceless %}
 {% endblock money_widget %}


### PR DESCRIPTION
Hi,

I encountered a problem with the money_widget where you remove `{{ widget }}` from the `money_pattern`. 
The problem is, that if you specify a currency in your form field, the `money_pattern` looks as follows: `{{ widget }} <currency>` (e.g. `{{ widget }} <currency>`). Also have a look at the Symfony implementation: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php#L72-L112

This again leads to missing translation errors even if you specify a translation for your currency but forget to add the leading space.

The solution is to trim the money_widget after manipulating it.