### PR TITLE
Fixed fonts path for configurations where the site is not in root path.

### DIFF
--- a/Resources/public/less/mopabootstrapbundle.less
+++ b/Resources/public/less/mopabootstrapbundle.less
@@ -22,7 +22,7 @@
 @import "../bootstrap/less/bootstrap.less";
 
 // variables
-@icon-font-path: "/fonts/";
+@icon-font-path: "../fonts/";
 
 // The Paginator less for MopaBootstrapBundle
 @import "paginator.less";


### PR DESCRIPTION
This fixes fonts path in CSS files, when the symfony app is running in a subpath.