### PR TITLE
make inline buttons abled to be disabled

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -219,14 +219,15 @@
             {% else %}
                 {% set label_attr_copy = label_attr|default({}) %}
             {% endif %}
-            <label{% for attrname, attrvalue in label_attr_copy %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+            <button{% for attrname, attrvalue in label_attr_copy %} {{ attrname }}="{{ attrvalue }}"{% endfor %}
+            {%- if disabled %} disabled="disabled"{% endif -%}>
             {{ form_widget(child, {'horizontal_label_class': horizontal_label_class, 'horizontal_input_wrapper_class': horizontal_input_wrapper_class, 'attr': {'class': attr.widget_class|default('') }}) }}
             {% if widget_type == 'inline-btn' or widget_checkbox_label == 'widget'%}
                 {{ child.vars.label|trans({}, translation_domain)|raw }}
             {% else %}
                 {{ child.vars.label|trans({}, translation_domain) }}
             {% endif %}
-            </label>
+            </button>
             {% if widget_type not in ['inline', 'inline-btn'] %}
                 </div>
             {% endif %}


### PR DESCRIPTION
@isometriks @all

I recently experiencend problems on natively disabling inline buttons via symfony2/3 forms.

Does anybody see a big problem in this, or shall we do a minor version bump and tracking in Changelog?

display due to bootstrap is the same, just css / js selectors might have to change.