### PR TITLE
Fix degradation of fontawesome font path

### DIFF
--- a/Resources/public/less/font-awesome/variables.less
+++ b/Resources/public/less/font-awesome/variables.less
@@ -1,7 +1,7 @@
 // Variables
 // --------------------------
 
-@fa-font-path:        "../fonts";
+@fa-font-path:        @FontAwesomePath;
 @fa-font-size-base:   14px;
 @fa-line-height-base: 1;
 //@fa-font-path:        "//netdna.bootstrapcdn.com/font-awesome/4.4.0/fonts"; // for referencing Bootstrap CDN font files directly


### PR DESCRIPTION
Fixing fontawesome font path in [#934](https://github.com/phiamo/MopaBootstrapBundle/pull/934/files#diff-0915b51dacc49d9f5891830bc727c9dfR4) is broken by [#1119](https://github.com/phiamo/MopaBootstrapBundle/pull/1119/commits/5ca274aa195d3cf9c0497453a03d4fc9e772172c#diff-0915b51dacc49d9f5891830bc727c9dfR4). This PR fixes this degradation.
Thanks.

> This is totally same fix as my previous PR #1092 but just for `fontawesome` not `fontawesome4`