### PR TITLE
Fixed calling old twig function

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -204,7 +204,7 @@
         {% if expanded %}
             {% set attr = attr|merge({'class': attr.class|default('') ~ ' ' ~ horizontal_input_wrapper_class}) %}
         {% endif %}
-        {% if layout is sameas(false) %}
+        {% if layout is same as(false) %}
             <div>
         {% endif %}
         {% if widget_type == 'inline-btn' %}
@@ -243,7 +243,7 @@
         {% if widget_type == 'inline-btn' %}
             </div>
         {% endif %}
-        {% if layout is sameas(false) %}
+        {% if layout is same as(false) %}
             </div>
         {% endif %}
     {% endspaceless %}


### PR DESCRIPTION
The function `sameas` is deprecated since twig 1.x and was replaced with `same as`. Twig 2.x won't work anymore.

Refs https://twig.symfony.com/doc/1.x/deprecated.html#tests