### PR TITLE
Register commands as services

### DIFF
--- a/DependencyInjection/MopaBootstrapExtension.php
+++ b/DependencyInjection/MopaBootstrapExtension.php
@@ -29,6 +29,7 @@ class MopaBootstrapExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('bootstrap.xml');
         $loader->load('twig.xml');
+        $loader->load('command.xml');
 
         if (isset($config['bootstrap'])) {
             if (!isset($config['bootstrap']['install_path'])) {

--- a/Resources/config/command.xml
+++ b/Resources/config/command.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Mopa\Bundle\BootstrapBundle\Command\BootstrapSymlinkLessCommand" class="Mopa\Bundle\BootstrapBundle\Command\BootstrapSymlinkLessCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Mopa\Bundle\BootstrapBundle\Command\BootstrapSymlinkSassCommand" class="Mopa\Bundle\BootstrapBundle\Command\BootstrapSymlinkSassCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+        <service id="Mopa\Bundle\BootstrapBundle\Command\InstallFontCommand" class="Mopa\Bundle\BootstrapBundle\Command\InstallFontCommand" public="true">
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Auto-registration of commands is deprecated since Symfony 3.4 and is not supported in 4.0