### PR TITLE
Add embed form id in parent div

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -758,7 +758,7 @@
     {% if help_widget_popover.selector is same as(null) %}
         {% set help_widget_popover = help_widget_popover|merge({'selector': '#' ~ id }) %}
     {% endif %}
-    <div{% if help_widget_popover.title is not same as(null) %}{{ block('help_widget_popover') }}{% endif %} {% for attrname,attrvalue in widget_form_group_attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
+    <div {% if form.vars.compound %}id="{{ form.vars.id }}"{% endif %} {% if help_widget_popover.title is not same as(null) %}{{ block('help_widget_popover') }}{% endif %} {% for attrname,attrvalue in widget_form_group_attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>
     {# a form item containing the field in block_prefixes is a near subform or a field directly #}
     {% if (form|length > 0 and form.parent != null)
         and 'field' not in form.vars.block_prefixes


### PR DESCRIPTION
When using an embed form, currently it displays like this :

```
<div class="form-group">
    <div id="my_form_foo" class="form-group">...</div>
    <div id="my_form_bar" class="form-group">...</div>
</div>
```
This PR adds the form id to the top level div, selecting it is now easier :

```
<div id="my_form" class="form-group">
    <div id="my_form_foo" class="form-group">...</div>
    <div id="my_form_bar" class="form-group">...</div>
</div>
```