### PR TITLE
Fixed sf43 deprecations for future compatibility

### DIFF
--- a/Command/BaseBootstrapSymlinkCommand.php
+++ b/Command/BaseBootstrapSymlinkCommand.php
@@ -13,7 +13,7 @@ namespace Mopa\Bundle\BootstrapBundle\Command;
 
 use Mopa\Bridge\Composer\Adapter\ComposerAdapter;
 use Mopa\Bridge\Composer\Util\ComposerPathFinder;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,7 +25,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @author phiamo <phiamo@googlemail.com>
  */
-abstract class BaseBootstrapSymlinkCommand extends ContainerAwareCommand
+abstract class BaseBootstrapSymlinkCommand extends Command
 {
     public static $mopaBootstrapBundleName = 'mopa/bootstrap-bundle';
     public static $targetSuffix = '';
@@ -38,6 +38,17 @@ abstract class BaseBootstrapSymlinkCommand extends ContainerAwareCommand
      * @var OutputInterface
      */
     protected $output;
+    /**
+     * @var string
+     */
+    private $bootstrapInstallPath;
+
+    public function __construct($bootstrapInstallPath)
+    {
+        parent::__construct(null);
+
+        $this->bootstrapInstallPath = $bootstrapInstallPath;
+    }
 
     /**
      * Checks symlink's existence.
@@ -154,10 +165,9 @@ abstract class BaseBootstrapSymlinkCommand extends ContainerAwareCommand
         if ($input->getOption('manual')) {
             list($symlinkTarget, $symlinkName) = $this->getBootstrapPathsFromUser();
         } elseif (false !== $composer = ComposerAdapter::getComposer($input, $output)) {
-            $targetPath = $this->getContainer()->getParameter('mopa_bootstrap.bootstrap.install_path');
             $cmanager = new ComposerPathFinder($composer);
             $options = [
-                'targetSuffix' => DIRECTORY_SEPARATOR.$targetPath.static::$targetSuffix,
+                'targetSuffix' => DIRECTORY_SEPARATOR.$this->bootstrapInstallPath.static::$targetSuffix,
                 'sourcePrefix' => '..'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR,
             ];
             list($symlinkTarget, $symlinkName) = $cmanager->getSymlinkFromComposer(

--- a/Command/InstallFontCommand.php
+++ b/Command/InstallFontCommand.php
@@ -13,16 +13,18 @@ namespace Mopa\Bundle\BootstrapBundle\Command;
 
 use Mopa\Bridge\Composer\Adapter\ComposerAdapter;
 use Mopa\Bridge\Composer\Util\ComposerPathFinder;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Command to create Bootstrap symlink to MopaBootstrapBundle.
  */
-class InstallFontCommand extends ContainerAwareCommand
+class InstallFontCommand extends Command
 {
     public static $iconSetsPaths = [
         'glyphicons' => 'fonts/bootstrap',
@@ -30,6 +32,22 @@ class InstallFontCommand extends ContainerAwareCommand
         'fontawesome4' => 'fonts/fa4',
         'zmdi' => 'fonts/zmdi',
     ];
+
+    /**
+     * @var KernelInterface
+     */
+    private $kernel;
+    /**
+     * @var string
+     */
+    private $iconSet;
+
+    public function __construct(KernelInterface $kernel, $iconSet)
+    {
+        parent::__construct(null);
+        $this->kernel = $kernel;
+        $this->iconSet = $iconSet;
+    }
 
     /**
      * {@inheritdoc}
@@ -54,9 +72,11 @@ EOT
     {
         $finder = new Finder();
 
-        $iconSet = $this->getContainer()->getParameter('mopa_bootstrap.icons.icon_set');
-
-        $webPath = $this->getContainer()->get('kernel')->getRootDir().DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'web';
+        if (Kernel::VERSION_ID >= 40200) {
+            $webPath = $this->kernel->getRootDir().DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'web';
+        } else {
+            $webPath = $this->kernel->getProjectDir().DIRECTORY_SEPARATOR.'web';
+        }
 
         $iconWebPath = $webPath.DIRECTORY_SEPARATOR.'fonts';
 
@@ -74,7 +94,7 @@ EOT
 
         $bsbPath = $composer->getInstallationManager()->getInstallPath($sourcePackage);
 
-        $iconSetPath = $bsbPath.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.self::$iconSetsPaths[$iconSet];
+        $iconSetPath = $bsbPath.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.self::$iconSetsPaths[$this->iconSet];
 
         $finder->files()->in($iconSetPath);
 
@@ -82,7 +102,7 @@ EOT
             $fs->copy($file->getRealpath(), $iconWebPath.DIRECTORY_SEPARATOR.$file->getRelativePathname());
         }
 
-        $output->writeln('Font: '.$iconSet.' Installed... <info>OK</info>');
+        $output->writeln('Font: '.$this->iconSet.' Installed... <info>OK</info>');
     }
 
     public static function installFonts()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,9 +11,11 @@
 
 namespace Mopa\Bundle\BootstrapBundle\DependencyInjection;
 
+use function method_exists;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class Configuration implements ConfigurationInterface
 {
@@ -24,8 +26,13 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder(self::KEY);
-        $rootNode = $treeBuilder->root(self::KEY);
+        if (Kernel::VERSION_ID >= 40200) {
+            $treeBuilder = new TreeBuilder(self::KEY);
+        } else {
+            $treeBuilder = new TreeBuilder();
+        }
+        $rootNode = method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root(self::KEY);
+
         $this->addFormConfig($rootNode);
         $this->addIconsConfig($rootNode);
         $this->addMenuConfig($rootNode);
@@ -436,8 +443,13 @@ class Configuration implements ConfigurationInterface
 
     protected function addTooltipNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('tooltip');
+        if (Kernel::VERSION_ID >= 40200) {
+            $builder = new TreeBuilder('tooltip');
+        } else {
+            $builder = new TreeBuilder();
+        }
+
+        $node = method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('tooltip');
 
         return $node
             ->addDefaultsIfNotSet()
@@ -460,8 +472,13 @@ class Configuration implements ConfigurationInterface
 
     protected function addPopoverNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('popover');
+        if (Kernel::VERSION_ID >= 40200) {
+            $builder = new TreeBuilder('popover');
+        } else {
+            $builder = new TreeBuilder();
+        }
+
+        $node = method_exists($builder, 'getRootNode') ? $builder->getRootNode() : $builder->root('popover');
 
         return $node
             ->addDefaultsIfNotSet()

--- a/Resources/config/command.xml
+++ b/Resources/config/command.xml
@@ -3,12 +3,16 @@
     <services>
         <service id="Mopa\Bundle\BootstrapBundle\Command\BootstrapSymlinkLessCommand" class="Mopa\Bundle\BootstrapBundle\Command\BootstrapSymlinkLessCommand" public="true">
             <tag name="console.command"/>
+            <argument type="string">%mopa_bootstrap.bootstrap.install_path%</argument>
         </service>
         <service id="Mopa\Bundle\BootstrapBundle\Command\BootstrapSymlinkSassCommand" class="Mopa\Bundle\BootstrapBundle\Command\BootstrapSymlinkSassCommand" public="true">
             <tag name="console.command"/>
+            <argument type="string">%mopa_bootstrap.bootstrap.install_path%</argument>
         </service>
         <service id="Mopa\Bundle\BootstrapBundle\Command\InstallFontCommand" class="Mopa\Bundle\BootstrapBundle\Command\InstallFontCommand" public="true">
             <tag name="console.command"/>
+            <argument type="service" id="kernel"/>
+            <argument>%mopa_bootstrap.icons.icon_set%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
When upgrading to 4.3 I got a bunch of deprecations, this PR should fix them.

Summary:
 - Fixed the root node access/creation in the Configuration
 - Commands no longer extend container aware

One remaining issue is that the `InstallFontCommand` is hardcoded to use the web directory, which is configurable in Symfony and defaults to `public`, but was outside of my scope.

Running phpunit gave me a bunch of risky tests as no assertions were made, so I've tested the changes in my own application:
 - ran the 3 commands with `--help` to see if their initialization works
 - compiled the container to see if the deprecations were gone