### PR TITLE
In symfony4 KernelTestCase class the field variable $container is sta…

### DIFF
--- a/Tests/Form/TypeTestCase.php
+++ b/Tests/Form/TypeTestCase.php
@@ -31,7 +31,7 @@ class TypeTestCase extends KernelTestCase
     /**
      * @var ContainerInterface
      */
-    protected $container;
+    protected static $container;
 
     /**
      * @var FormFactoryInterface


### PR DESCRIPTION
In symfony4 KernelTestCase class the field variable $container is static. Test don't work any more if there based on this test class. 